### PR TITLE
Add language context and navbar toggle for locale switching

### DIFF
--- a/client/ama/index.html
+++ b/client/ama/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ar" dir="rtl">
+<html lang="" dir="">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./src/assets/logo.png" />

--- a/client/ama/src/components/LanguageToggle.tsx
+++ b/client/ama/src/components/LanguageToggle.tsx
@@ -1,0 +1,41 @@
+import { useId } from "react";
+
+import { useLanguage } from "@/context/LanguageContext";
+
+const LANGUAGE_OPTIONS = [
+  { code: "ar", label: "العربية" },
+  { code: "he", label: "עברית" },
+] as const;
+
+type LanguageCode = (typeof LANGUAGE_OPTIONS)[number]["code"];
+
+interface LanguageToggleProps {
+  className?: string;
+}
+
+const LanguageToggle = ({ className }: LanguageToggleProps) => {
+  const { locale, setLocale } = useLanguage();
+  const selectId = useId();
+
+  return (
+    <div className={className}>
+      <label htmlFor={selectId} className="sr-only">
+        اختر اللغة
+      </label>
+      <select
+        id={selectId}
+        value={locale}
+        onChange={(event) => setLocale(event.target.value as LanguageCode)}
+        className="h-9 min-w-[6rem] rounded-md border border-border bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {LANGUAGE_OPTIONS.map((option) => (
+          <option key={option.code} value={option.code}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default LanguageToggle;

--- a/client/ama/src/components/Navbar.tsx
+++ b/client/ama/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Menu } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import ThemeToggle from "@/components/ThemeToggle";
+import LanguageToggle from "@/components/LanguageToggle";
 import { useTranslation } from "@/i18n";
 // import OfferBanner from "./common/OfferBanner";
 
@@ -17,6 +18,7 @@ const Navbar: React.FC = () => {
   // const bannerinfo = useRef(
   //   "خصم اجمالي على كل الفواتير الاعلى من ١٠٠٠ شيقل بقيمه ٥٪"
   // );
+  const showThemeToggle = !user || user.role !== "admin";
   const baseLinks = useMemo(
     () => [
       { key: "home", path: "/" },
@@ -50,15 +52,17 @@ const Navbar: React.FC = () => {
 
       <nav className="container mx-auto p-4 flex items-center justify-between">
         {/* الشعار */}
-        {!user && <ThemeToggle />}
-        {user && user.role != "admin" && <ThemeToggle />}
+        <div className="flex items-center gap-2">
+          <LanguageToggle className="w-24" />
+          {showThemeToggle && <ThemeToggle />}
+        </div>
         <Link to="/" className="text-2xl font-bold min-w-45">
           {t("navbar.brand")}
         </Link>
         {/* <div className="bg-testRed">لو ظهر أحمر، كل شيء تمام</div> */}
 
         {/* زر القائمة للجوال */}
-        <div className="flex items-center gap-4 lg:hidden">
+        <div className="flex items-center gap-3 lg:hidden">
           <CartButton />
           <Button
             variant="ghost"
@@ -160,6 +164,8 @@ const Navbar: React.FC = () => {
               </button>
             </>
           )}
+
+          <LanguageToggle className="w-full" />
         </div>
       )}
     </header>

--- a/client/ama/src/context/LanguageContext.tsx
+++ b/client/ama/src/context/LanguageContext.tsx
@@ -1,0 +1,120 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import i18n, { resources } from "@/i18n";
+
+type SupportedLocale = keyof typeof resources;
+
+type TextDirection = "ltr" | "rtl";
+
+interface LanguageContextValue {
+  locale: SupportedLocale;
+  direction: TextDirection;
+  setLocale: (locale: SupportedLocale) => void;
+}
+
+const RTL_LANGUAGES = new Set<SupportedLocale>(["ar", "he"]);
+
+const STORAGE_KEY = "app-language";
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(
+  undefined
+);
+
+const resolveDirection = (locale: SupportedLocale): TextDirection =>
+  RTL_LANGUAGES.has(locale) ? "rtl" : "ltr";
+
+const isSupportedLocale = (value: string): value is SupportedLocale =>
+  value in resources;
+
+const getInitialLocale = (): SupportedLocale => {
+  if (typeof window === "undefined") {
+    return (i18n.language as SupportedLocale) ?? "ar";
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+
+  if (stored && isSupportedLocale(stored)) {
+    return stored;
+  }
+
+  return (i18n.language as SupportedLocale) ?? "ar";
+};
+
+export const LanguageProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [locale, setLocaleState] = useState<SupportedLocale>(getInitialLocale);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    localStorage.setItem(STORAGE_KEY, locale);
+  }, [locale]);
+
+  useEffect(() => {
+    void i18n.changeLanguage(locale);
+  }, [locale]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.documentElement.lang = locale;
+    document.documentElement.dir = resolveDirection(locale);
+  }, [locale]);
+
+  useEffect(() => {
+    const handleLanguageChange = (nextLocale: string) => {
+      if (isSupportedLocale(nextLocale) && nextLocale !== locale) {
+        setLocaleState(nextLocale);
+      }
+    };
+
+    i18n.on("languageChanged", handleLanguageChange);
+
+    return () => {
+      i18n.off("languageChanged", handleLanguageChange);
+    };
+  }, [locale]);
+
+  const setLocale = useCallback((value: SupportedLocale) => {
+    setLocaleState(value);
+  }, []);
+
+  const direction = resolveDirection(locale);
+
+  const value = useMemo(
+    () => ({
+      locale,
+      direction,
+      setLocale,
+    }),
+    [direction, locale, setLocale]
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = (): LanguageContextValue => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+};

--- a/client/ama/src/index.css
+++ b/client/ama/src/index.css
@@ -157,5 +157,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    direction: inherit;
+    text-align: start;
   }
 }

--- a/client/ama/src/main.tsx
+++ b/client/ama/src/main.tsx
@@ -7,17 +7,20 @@ import { I18nextProvider } from "react-i18next";
 import "./index.css";
 import App from "./App.tsx";
 import { AuthProvider } from "./context/AuthContext.tsx";
+import { LanguageProvider } from "./context/LanguageContext";
 import i18n from "./i18n";
 
 createRoot(document.getElementById("root")!).render(
   <I18nextProvider i18n={i18n}>
-    <AuthProvider>
-      <CartProvider>
-        <BrowserRouter>
-          <SpeedInsights />
-          <App />
-        </BrowserRouter>
-      </CartProvider>
-    </AuthProvider>
+    <LanguageProvider>
+      <AuthProvider>
+        <CartProvider>
+          <BrowserRouter>
+            <SpeedInsights />
+            <App />
+          </BrowserRouter>
+        </CartProvider>
+      </AuthProvider>
+    </LanguageProvider>
   </I18nextProvider>
 );


### PR DESCRIPTION
## Summary
- add a LanguageContext that stores the active locale, syncs document direction, and persists the choice
- add a reusable LanguageToggle component and integrate it into the navbar and mobile menu
- wrap the app with the LanguageProvider, default HTML lang/dir attributes to empty strings, and ensure base CSS respects direction inheritance

## Testing
- npm run lint *(fails: pre-existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68da3d38868c8330b14088c225db95b0