### PR TITLE
Allow localized inputs to retain whitespace while editing

### DIFF
--- a/client/ama/src/components/admin/ProductEditDialog.tsx
+++ b/client/ama/src/components/admin/ProductEditDialog.tsx
@@ -60,8 +60,10 @@ const ProductEditDialog: React.FC<ProductEditDialogProps> = ({
 
   if (!editingProduct) return null;
 
-  const nameState = ensureLocalizedObject(editingProduct.name);
-  const descriptionState = ensureLocalizedObject(editingProduct.description);
+  const nameState = ensureLocalizedObject(editingProduct.name, { trim: false });
+  const descriptionState = ensureLocalizedObject(editingProduct.description, {
+    trim: false,
+  });
 
   const handleSave = async () => {
     try {
@@ -71,13 +73,25 @@ const ProductEditDialog: React.FC<ProductEditDialogProps> = ({
         ? String(editingProduct.ownershipType)
         : "ours";
 
-      const normalizedName = ensureLocalizedObject(editingProduct.name);
+      const normalizedName = ensureLocalizedObject(editingProduct.name, {
+        trim: false,
+      });
       const normalizedDescription = ensureLocalizedObject(
-        editingProduct.description
+        editingProduct.description,
+        { trim: false }
       );
 
+      const sanitizedName = {
+        ar: normalizedName.ar.trim(),
+        he: normalizedName.he.trim(),
+      };
+      const sanitizedDescription = {
+        ar: normalizedDescription.ar.trim(),
+        he: normalizedDescription.he.trim(),
+      };
+
       const payload: Record<string, unknown> = {
-        name: normalizedName,
+        name: sanitizedName,
         mainCategory: editingProduct.mainCategory?.trim(),
         subCategory: editingProduct.subCategory?.trim(),
         images: Array.isArray(editingProduct.images)
@@ -86,8 +100,8 @@ const ProductEditDialog: React.FC<ProductEditDialogProps> = ({
         ownershipType, // 👈 إرسال نوع الملكية
       };
 
-      if (normalizedDescription.ar || normalizedDescription.he) {
-        payload.description = normalizedDescription;
+      if (sanitizedDescription.ar || sanitizedDescription.he) {
+        payload.description = sanitizedDescription;
       }
 
       const res = await axios.put(
@@ -168,7 +182,9 @@ const ProductEditDialog: React.FC<ProductEditDialogProps> = ({
                     setEditingProduct({
                       ...editingProduct,
                       name: {
-                        ...ensureLocalizedObject(editingProduct.name),
+                        ...ensureLocalizedObject(editingProduct.name, {
+                          trim: false,
+                        }),
                         [code]: e.target.value,
                       },
                     })
@@ -260,7 +276,9 @@ const ProductEditDialog: React.FC<ProductEditDialogProps> = ({
                     setEditingProduct({
                       ...editingProduct,
                       description: {
-                        ...ensureLocalizedObject(editingProduct.description),
+                        ...ensureLocalizedObject(editingProduct.description, {
+                          trim: false,
+                        }),
                         [code]: e.target.value,
                       },
                     })

--- a/client/ama/src/components/admin/ProductForm.tsx
+++ b/client/ama/src/components/admin/ProductForm.tsx
@@ -59,8 +59,10 @@ const ProductForm: React.FC<ProductFormProps> = ({
     { code: "he", label: t("admin.languages.he") },
   ];
 
-  const nameState = ensureLocalizedObject(newProduct.name);
-  const descriptionState = ensureLocalizedObject(newProduct.description);
+  const nameState = ensureLocalizedObject(newProduct.name, { trim: false });
+  const descriptionState = ensureLocalizedObject(newProduct.description, {
+    trim: false,
+  });
 
   // إضافة صورة
   const handleAddImage = () => {
@@ -95,13 +97,25 @@ const ProductForm: React.FC<ProductFormProps> = ({
         ? String(newProduct.priority)
         : "C";
 
-      const normalizedName = ensureLocalizedObject(newProduct.name);
+      const normalizedName = ensureLocalizedObject(newProduct.name, {
+        trim: false,
+      });
       const normalizedDescription = ensureLocalizedObject(
-        newProduct.description
+        newProduct.description,
+        { trim: false }
       );
 
+      const sanitizedName = {
+        ar: normalizedName.ar.trim(),
+        he: normalizedName.he.trim(),
+      };
+      const sanitizedDescription = {
+        ar: normalizedDescription.ar.trim(),
+        he: normalizedDescription.he.trim(),
+      };
+
       const payload: Record<string, unknown> = {
-        name: normalizedName,
+        name: sanitizedName,
         mainCategory: newProduct.mainCategory?.trim(),
         subCategory: newProduct.subCategory?.trim(),
         images: Array.isArray(newProduct.images) ? newProduct.images : [],
@@ -109,8 +123,8 @@ const ProductForm: React.FC<ProductFormProps> = ({
         priority,
       };
 
-      if (normalizedDescription.ar || normalizedDescription.he) {
-        payload.description = normalizedDescription;
+      if (sanitizedDescription.ar || sanitizedDescription.he) {
+        payload.description = sanitizedDescription;
       }
 
       const res = await axios.post(
@@ -180,7 +194,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
                     setNewProduct((prev: any) => ({
                       ...prev,
                       name: {
-                        ...ensureLocalizedObject(prev.name),
+                        ...ensureLocalizedObject(prev.name, { trim: false }),
                         [code]: e.target.value,
                       },
                     }))
@@ -298,7 +312,9 @@ const ProductForm: React.FC<ProductFormProps> = ({
                     setNewProduct((prev: any) => ({
                       ...prev,
                       description: {
-                        ...ensureLocalizedObject(prev.description),
+                        ...ensureLocalizedObject(prev.description, {
+                          trim: false,
+                        }),
                         [code]: e.target.value,
                       },
                     }))

--- a/client/ama/src/lib/localized.ts
+++ b/client/ama/src/lib/localized.ts
@@ -16,24 +16,40 @@ export type LocalizedObject = {
 
 export const emptyLocalized: LocalizedObject = { ar: "", he: "" };
 
-const trimOrEmpty = (value: string | null | undefined) =>
-  value ? value.toString().trim() : "";
+type EnsureLocalizedOptions = {
+  trim?: boolean;
+};
+
+const normalizeValue = (
+  value: string | null | undefined,
+  { trim = true }: EnsureLocalizedOptions
+) => {
+  if (value == null) {
+    return "";
+  }
+
+  const stringified = value.toString();
+  return trim ? stringified.trim() : stringified;
+};
 
 export const ensureLocalizedObject = (
-  value: LocalizedText
+  value: LocalizedText,
+  options: EnsureLocalizedOptions = {}
 ): LocalizedObject => {
+  const { trim = true } = options;
+
   if (!value) {
     return { ...emptyLocalized };
   }
 
   if (typeof value === "string") {
-    const trimmed = value.trim();
-    return { ar: trimmed, he: "" };
+    const normalized = trim ? value.trim() : value;
+    return { ar: normalized, he: "" };
   }
 
   return {
-    ar: trimOrEmpty(value.ar),
-    he: trimOrEmpty(value.he),
+    ar: normalizeValue(value.ar, { trim }),
+    he: normalizeValue(value.he, { trim }),
   };
 };
 


### PR DESCRIPTION
## Summary
- add an option to `ensureLocalizedObject` so localized form state can retain whitespace while users edit text
- update the product create/edit dialogs to avoid trimming localized inputs during editing but trim right before sending API payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da86085acc8330bfa4d608759f08ae