### PR TITLE
Internationalize product details page content

### DIFF
--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -120,6 +120,35 @@
       ]
     }
   },
+  "productDetails": {
+    "loading": "جاري تحميل تفاصيل المنتج...",
+    "measureLabel": "المقاس",
+    "colorLabel": "اللون",
+    "colorUnavailable": "— غير متاح لهذا المقاس",
+    "price": {
+      "selectOptions": "اختر مقاسًا ولونًا"
+    },
+    "discount": {
+      "ended": "انتهى الخصم",
+      "progressAria": "مدّة الخصم المتبقية",
+      "progressTitle": "مدّة الخصم",
+      "endsIn": "ينتهي خلال:",
+      "parts": {
+        "days": "{{value}}ي",
+        "hours": "{{value}}س",
+        "minutes": "{{value}}د",
+        "seconds": "{{value}}ث"
+      }
+    },
+    "availability": {
+      "label": "المتوفر: {{count}}",
+      "sku": " • SKU: {{sku}}"
+    },
+    "cta": {
+      "addToCart": "إضافة للسلة",
+      "outOfStock": "غير متوفر"
+    }
+  },
   "common": {
     "all": "الكل",
     "loading": "جارٍ التحميل…",

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -180,6 +180,35 @@
       ]
     }
   },
+  "productDetails": {
+    "loading": "טוען פרטי מוצר...",
+    "measureLabel": "מידה",
+    "colorLabel": "צבע",
+    "colorUnavailable": "— לא זמין במידה זו",
+    "price": {
+      "selectOptions": "בחרו מידה וצבע"
+    },
+    "discount": {
+      "ended": "ההנחה הסתיימה",
+      "progressAria": "הזמן שנותר להנחה",
+      "progressTitle": "משך ההנחה",
+      "endsIn": "נגמר בעוד:",
+      "parts": {
+        "days": "{{value}} ימים",
+        "hours": "{{value}} שעות",
+        "minutes": "{{value}} דקות",
+        "seconds": "{{value}} שניות"
+      }
+    },
+    "availability": {
+      "label": "זמין במלאי: {{count}}",
+      "sku": " • SKU: {{sku}}"
+    },
+    "cta": {
+      "addToCart": "הוספה לעגלה",
+      "outOfStock": "אזל מהמלאי"
+    }
+  },
   "common": {
     "all": "הכול",
     "loading": "טוען…",


### PR DESCRIPTION
## Summary
- localize product details UI labels, availability, and CTAs through the shared i18n hook
- restructure the countdown formatter to expose translated time-unit parts and update timer accessibility text
- add the required Arabic and Hebrew locale strings for the product details view

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db793f07d88330a3be1295f6cacff8