### PR TITLE
Add export script for image manifests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,25 @@ node scripts/download-images.js --out ./my-folder --concurrency 8
 ```
 
 If any downloads fail, the script exits with a non-zero status so it can be used in automated workflows.
+
+### 9. Exporting Image Manifests
+
+To generate a quick reference of which documents own which image URLs, export manifest files with the accompanying script:
+
+```bash
+cd server
+npm run export:image-manifests
+```
+
+By default the script writes two JSON Lines files under `server/downloads/manifests/`:
+
+- `products.jsonl` — each line is a JSON object shaped like `{ "_id": "<productId>", "images": ["<url>", ...] }`.
+- `variants.jsonl` — each line uses the same structure for variant documents.
+
+Every JSON object appears entirely on a single line so it's easy to process with standard command-line tools. You can customize the output paths via CLI flags:
+
+```bash
+node scripts/export-image-manifests.js --product-out ./manifests/products.jsonl --variant-out ./manifests/variants.jsonl
+```
+
+The command exits with a non-zero code if either manifest cannot be written, which makes it safe to plug into automated workflows or CI jobs.

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "test": "node --test",
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "download:images": "node scripts/download-images.js --out downloads/images"
+    "download:images": "node scripts/download-images.js --out downloads/images",
+    "export:image-manifests": "node scripts/export-image-manifests.js"
   },
   "keywords": [],
   "author": "",

--- a/server/scripts/download-images.js
+++ b/server/scripts/download-images.js
@@ -11,6 +11,7 @@ const {
 } = require("../utils/config");
 const Product = require("../models/Product");
 const Variant = require("../models/Variant");
+const { extractImageUrls } = require("./utils/image-helpers");
 
 const DEFAULT_OUTPUT = path.join(__dirname, "..", "downloads", "images");
 const DEFAULT_CONCURRENCY = 4;
@@ -101,19 +102,6 @@ async function fetchImage(url, index, outDir) {
   }
 }
 
-function extractUrls(docs, getter) {
-  const urls = [];
-  for (const doc of docs) {
-    const values = getter(doc);
-    for (const url of values) {
-      if (typeof url === "string" && url.trim()) {
-        urls.push(url.trim());
-      }
-    }
-  }
-  return urls;
-}
-
 async function main() {
   const options = parseArgs();
   await fs.promises.mkdir(options.out, { recursive: true });
@@ -125,8 +113,8 @@ async function main() {
     Variant.find({}, { "color.images": 1 }).lean(),
   ]);
 
-  const productUrls = extractUrls(productDocs, (doc) => doc.images || []);
-  const variantUrls = extractUrls(variantDocs, (doc) => (doc.color?.images) || []);
+  const productUrls = extractImageUrls(productDocs, (doc) => doc.images || []);
+  const variantUrls = extractImageUrls(variantDocs, (doc) => doc.color?.images || []);
 
   const uniqueUrls = Array.from(new Set([...productUrls, ...variantUrls]));
   console.log(`🧮 Found ${uniqueUrls.length} unique image URL(s).`);

--- a/server/scripts/export-image-manifests.js
+++ b/server/scripts/export-image-manifests.js
@@ -1,0 +1,124 @@
+// server/scripts/export-image-manifests.js
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+
+const {
+  connectToDatabase,
+  disconnectFromDatabase,
+} = require("../utils/config");
+const Product = require("../models/Product");
+const Variant = require("../models/Variant");
+const { sanitizeImageList } = require("./utils/image-helpers");
+
+const DEFAULT_OUTPUT_DIR = path.join(
+  __dirname,
+  "..",
+  "downloads",
+  "manifests"
+);
+const DEFAULT_PRODUCT_OUT = path.join(DEFAULT_OUTPUT_DIR, "products.jsonl");
+const DEFAULT_VARIANT_OUT = path.join(DEFAULT_OUTPUT_DIR, "variants.jsonl");
+
+function printHelp() {
+  console.log(
+    `Usage: node scripts/export-image-manifests.js [options]\n\n` +
+      `Options:\n` +
+      `  --product-out <file>   Product manifest destination (default: ${DEFAULT_PRODUCT_OUT})\n` +
+      `  --variant-out <file>   Variant manifest destination (default: ${DEFAULT_VARIANT_OUT})\n` +
+      `  -h, --help             Show this message\n`
+  );
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const options = {
+    productOut: DEFAULT_PRODUCT_OUT,
+    variantOut: DEFAULT_VARIANT_OUT,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--product-out") {
+      options.productOut = args[++i];
+    } else if (arg.startsWith("--product-out=")) {
+      options.productOut = arg.slice("--product-out=".length);
+    } else if (arg === "--variant-out") {
+      options.variantOut = args[++i];
+    } else if (arg.startsWith("--variant-out=")) {
+      options.variantOut = arg.slice("--variant-out=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.warn(`⚠️ Unknown argument ignored: ${arg}`);
+    }
+  }
+
+  if (!options.productOut) options.productOut = DEFAULT_PRODUCT_OUT;
+  if (!options.variantOut) options.variantOut = DEFAULT_VARIANT_OUT;
+
+  options.productOut = path.resolve(process.cwd(), options.productOut);
+  options.variantOut = path.resolve(process.cwd(), options.variantOut);
+
+  return options;
+}
+
+function buildManifestEntries(docs, getImages) {
+  return (docs || []).map((doc) => ({
+    _id: String(doc._id),
+    images: sanitizeImageList(getImages(doc)),
+  }));
+}
+
+async function writeManifest(entries, filePath, label) {
+  try {
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    const lines = entries.map((entry) => JSON.stringify(entry));
+    const payload = lines.join("\n") + (lines.length ? "\n" : "");
+    await fs.promises.writeFile(filePath, payload, "utf8");
+    console.log(`✅ Wrote ${entries.length} ${label} entr${entries.length === 1 ? "y" : "ies"} to ${filePath}`);
+    return true;
+  } catch (error) {
+    const message = error?.stack || error?.message || String(error);
+    console.error(`❌ Failed to write ${label} manifest at ${filePath}: ${message}`);
+    return false;
+  }
+}
+
+async function main() {
+  const options = parseArgs();
+  await connectToDatabase();
+
+  const [productDocs, variantDocs] = await Promise.all([
+    Product.find({}, { images: 1 }).lean(),
+    Variant.find({}, { product: 1, "color.images": 1 }).lean(),
+  ]);
+
+  const productEntries = buildManifestEntries(productDocs, (doc) => doc.images || []);
+  const variantEntries = buildManifestEntries(variantDocs, (doc) => doc.color?.images || []);
+
+  const productWriteOk = await writeManifest(productEntries, options.productOut, "product");
+  const variantWriteOk = await writeManifest(variantEntries, options.variantOut, "variant");
+
+  if (!productWriteOk || !variantWriteOk) {
+    process.exitCode = 1;
+  }
+}
+
+(async () => {
+  try {
+    await main();
+  } catch (error) {
+    const message = error?.stack || error?.message || String(error);
+    console.error(`❌ Unexpected error: ${message}`);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await disconnectFromDatabase();
+    } catch (err) {
+      console.error(`⚠️ Failed to close Mongo connection: ${err?.message || err}`);
+      if (!process.exitCode) process.exitCode = 1;
+    }
+  }
+})();

--- a/server/scripts/utils/image-helpers.js
+++ b/server/scripts/utils/image-helpers.js
@@ -1,0 +1,38 @@
+// server/scripts/utils/image-helpers.js
+function sanitizeImageList(values) {
+  if (!Array.isArray(values)) return [];
+
+  const deduped = [];
+  const seen = new Set();
+
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    deduped.push(trimmed);
+  }
+
+  return deduped;
+}
+
+function extractImageUrls(documents, getter) {
+  const urls = [];
+  for (const doc of documents || []) {
+    try {
+      const images = getter(doc);
+      for (const url of sanitizeImageList(images)) {
+        urls.push(url);
+      }
+    } catch (error) {
+      // Swallow getter errors so one malformed doc does not halt the process.
+    }
+  }
+  return urls;
+}
+
+module.exports = {
+  sanitizeImageList,
+  extractImageUrls,
+};


### PR DESCRIPTION
## Summary
- add a manifest export script that queries products and variants and writes JSONL files
- share image URL normalization helpers between the export and download scripts
- document the new workflow and register an npm script for easy execution

## Testing
- not run (requires database connection)

------
https://chatgpt.com/codex/tasks/task_e_68db9a11780c833091bdce72078aa652