### PR TITLE
Stop focusing search input on category selection

### DIFF
--- a/client/ama/src/pages/Products.tsx
+++ b/client/ama/src/pages/Products.tsx
@@ -579,7 +579,6 @@ const Products: React.FC = () => {
     setSelectedMainCategory(main);
     setSelectedSubCategory(sub);
     setCurrentPage(1);
-    searchRef.current?.focus();
   };
 
   const categoryGroups = useMemo(() => {


### PR DESCRIPTION
## Summary
- prevent the category selection handler from forcing focus back onto the search input so category/subcategory clicks do not shift focus unexpectedly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0bd42c9a883308eee8299c86d8aff