### PR TITLE
Add configurable CORS allowlist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,3 +90,15 @@ node scripts/export-image-manifests.js --product-out ./manifests/products.jsonl 
 ```
 
 The command exits with a non-zero code if either manifest cannot be written, which makes it safe to plug into automated workflows or CI jobs.
+
+### 10. CORS Configuration
+
+The API only issues credentialed CORS responses to trusted front-end origins. Configure the allowlist with the `CLIENT_ORIGINS`
+environment variable, supplying a comma-separated list of fully-qualified origins (for example,
+```
+CLIENT_ORIGINS="https://shop.example.com,https://admin.example.com"
+```).
+
+If `CLIENT_ORIGINS` is omitted the server automatically allows localhost and 127.0.0.1 origins so developers can work without
+extra configuration. Requests arriving from any other origin receive a non-credentialed CORS response, preventing browsers from
+sending or receiving cookies and other sensitive credentials.


### PR DESCRIPTION
## Summary
- gate CORS credentials behind an allowlist parsed from the CLIENT_ORIGINS environment variable
- keep localhost origins working by default for development setups
- document the new CLIENT_ORIGINS configuration option for production deployments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0bfce2914833097c4d83ae4ce82ef