### PR TITLE
Validate Lahza payments before marking orders paid

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -97,6 +97,10 @@ const OrderSchema = new mongoose.Schema(
       default: "cod",
       index: true,
     },
+    paymentCurrency: {
+      type: String,
+      default: () => process.env.PAY_CURRENCY || "ILS",
+    },
     paymentStatus: {
       type: String,
       enum: ["unpaid", "paid", "failed"],
@@ -104,6 +108,9 @@ const OrderSchema = new mongoose.Schema(
       index: true,
     },
     reference: { type: String, index: true, default: null },
+    paymentVerifiedAmount: { type: Number, min: 0, default: null },
+    paymentVerifiedCurrency: { type: String, default: "" },
+    paymentTransactionId: { type: String, default: "" },
     notes: { type: String, default: "" },
   },
   { timestamps: true }

--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -100,6 +100,7 @@ router.post("/create", verifyTokenOptional, async (req, res) => {
         $set: {
           reference,
           paymentMethod: "card",
+          paymentCurrency: currency,
         },
       },
       { new: true }

--- a/server/utils/lahza.js
+++ b/server/utils/lahza.js
@@ -1,0 +1,88 @@
+// server/utils/lahza.js
+function toNumber(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function normalizeMinorAmount(...candidates) {
+  for (const candidate of candidates) {
+    const num = toNumber(candidate);
+    if (num === null) continue;
+    // Lahza amounts are returned in the smallest currency unit.
+    return Math.round(num);
+  }
+  return null;
+}
+
+function parseMetadata(raw) {
+  if (!raw) return {};
+  if (typeof raw === "object") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return { raw };
+    }
+  }
+  return {};
+}
+
+function extractCurrency(data = {}, metadata = {}) {
+  const value =
+    data.currency ||
+    data.currency_code ||
+    data.currencyCode ||
+    metadata.currency ||
+    metadata.expectedCurrency ||
+    "";
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function extractTransactionId(data = {}) {
+  return (
+    data.id ||
+    data.transaction_id ||
+    data.transactionId ||
+    data.txn_id ||
+    data.reference ||
+    data.ref ||
+    null
+  );
+}
+
+function mapVerificationPayload(raw = {}) {
+  const metadata = parseMetadata(raw.metadata);
+  const amountMinor = normalizeMinorAmount(
+    raw.amount_minor,
+    raw.amountMinor,
+    raw.amount,
+    metadata.amountMinor,
+    metadata.expectedAmountMinor
+  );
+
+  return {
+    status: String(raw.status || "").toLowerCase(),
+    amountMinor,
+    currency: extractCurrency(raw, metadata),
+    metadata,
+    transactionId: extractTransactionId(raw),
+  };
+}
+
+module.exports = {
+  normalizeMinorAmount,
+  parseMetadata,
+  mapVerificationPayload,
+};


### PR DESCRIPTION
## Summary
- add Lahza helpers to normalize verification payloads and persist reconciled payment details on orders
- validate webhook and admin payment flows against verified Lahza amounts and currency before marking an order paid
- capture the configured payment currency whenever orders are created or updated via Lahza

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0c49ea3e8833087a890c61515e4aa