### PR TITLE
Normalize IPv4 webhook IPs before whitelist check

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -86,16 +86,27 @@ const MINOR_AMOUNT_TOLERANCE = Number.isFinite(ENV_MINOR_TOLERANCE)
 const WEBHOOK_IP_WHITELIST =
   String(process.env.WEBHOOK_IP_WHITELIST || "true") === "true";
 
+function stripIpv4Port(candidate = "") {
+  const match = String(candidate)
+    .trim()
+    .match(/^(\d{1,3}(?:\.\d{1,3}){3})(?::\d+)?$/);
+  return match ? match[1] : "";
+}
+
 function normalizeIp(value = "") {
   if (!value) return "";
   const collapsed = String(value).trim().replace(/\s+/g, " ");
   if (!collapsed) return "";
   const mappedMatch = collapsed.match(/^::ffff:\s*(.+)$/i);
   if (mappedMatch) {
-    const candidate = mappedMatch[1].trim();
-    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(candidate)) {
+    const candidate = stripIpv4Port(mappedMatch[1]);
+    if (candidate) {
       return candidate;
     }
+  }
+  const ipv4 = stripIpv4Port(collapsed);
+  if (ipv4) {
+    return ipv4;
   }
   return collapsed;
 }

--- a/server/test/orders-and-payments.test.js
+++ b/server/test/orders-and-payments.test.js
@@ -6,7 +6,7 @@ const crypto = require("crypto");
 process.env.NODE_ENV = "test";
 process.env.JWT_SECRET = process.env.JWT_SECRET || "x".repeat(32);
 process.env.LAHZA_SECRET_KEY = "test-lahza-secret";
-process.env.WEBHOOK_ALLOWED_IPS = "203.0.113.5";
+process.env.WEBHOOK_ALLOWED_IPS = "::ffff:203.0.113.5:443";
 
 const ordersRouter = require("../routes/orders");
 const paymentsRouter = require("../routes/payments");
@@ -721,8 +721,8 @@ test(
     const req = {
       headers: {},
       body: rawBody,
-      socket: { remoteAddress: `::ffff:${allowedIp}` },
-      ip: `::ffff:${allowedIp}`,
+      socket: { remoteAddress: `::ffff:${allowedIp}:8443` },
+      ip: `::ffff:${allowedIp}:8443`,
       get(header) {
         if (header && header.toLowerCase() === "x-lahza-signature") {
           return signature;
@@ -748,9 +748,14 @@ test(
       "IPv6-mapped remote address should normalize to IPv4"
     );
     assert.equal(
-      normalizeIp(` ::ffff:${allowedIp} `),
+      normalizeIp(` ::ffff:${allowedIp}:1024 `),
       allowedIp,
       "normalizeIp should strip mapped prefix and whitespace"
+    );
+    assert.equal(
+      normalizeIp(`${allowedIp}:443`),
+      allowedIp,
+      "normalizeIp should drop trailing port from IPv4"
     );
   }
 );


### PR DESCRIPTION
## Summary
- strip optional port suffixes from IPv4 and IPv4-mapped addresses during webhook IP normalization
- reuse the enhanced normalization for the Lahza webhook whitelist to accept mapped addresses with port suffixes
- extend the webhook integration test to cover mapped IPv4 inputs that include a port and ensure the order is marked paid

## Testing
- node --test server/test/orders-and-payments.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0dad8abdc8330954ca368a7900d7b