### PR TITLE
Handle cart quantity when adding products

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -307,7 +307,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
             ? currentVariant.finalAmount
             : currentVariant.price?.amount ?? product.price ?? 0,
       };
-      addToCart(itemForCart);
+      addToCart(itemForCart, 1);
     } else {
       const productForCart = {
         ...product,
@@ -316,7 +316,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
         selectedColor,
         price: product.price ?? 0,
       };
-      addToCart(productForCart);
+      addToCart(productForCart, 1);
     }
   }, [
     addToCart,

--- a/client/ama/src/context/CartContext.tsx
+++ b/client/ama/src/context/CartContext.tsx
@@ -16,7 +16,7 @@ type CartItem = Product & { quantity: number };
 
 type CartContextType = {
   cart: CartItem[];
-  addToCart: (product: Product) => void;
+  addToCart: (product: Product, quantity?: number) => void;
   removeFromCart: (
     productId: string,
     selectedColor?: string,
@@ -75,8 +75,9 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
     return () => window.removeEventListener("storage", onStorage);
   }, []);
 
-  const addToCart = (product: Product) => {
+  const addToCart = (product: Product, quantity = 1) => {
     setCart((prev) => {
+      const clampedQuantity = Math.max(1, quantity);
       const existing = prev.find(
         (item) =>
           item._id === product._id &&
@@ -89,13 +90,13 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
           item._id === product._id &&
           item.selectedColor === product.selectedColor &&
           item.selectedMeasure === product.selectedMeasure
-            ? { ...item, quantity: item.quantity + 1 }
+            ? { ...item, quantity: item.quantity + clampedQuantity }
             : item
         );
       }
 
       // تأكد من وجود quantity 初 مرة
-      return [...prev, { ...product, quantity: 1 }];
+      return [...prev, { ...product, quantity: clampedQuantity }];
     });
   };
 

--- a/client/ama/src/pages/ProductDetails.tsx
+++ b/client/ama/src/pages/ProductDetails.tsx
@@ -509,18 +509,22 @@ const ProductDetails: React.FC = () => {
               disabled={!currentVariant || inStock <= 0}
               onClick={() => {
                 if (!currentVariant) return;
-                addToCart({
-                  ...product,
-                  selectedVariantId: currentVariant._id,
-                  selectedSku: currentVariant.stock.sku,
-                  selectedMeasure: currentVariant.measure,
-                  selectedMeasureUnit: currentVariant.measureUnit || undefined, // ✅
-                  selectedColor: currentVariant.color?.name,
-                  price:
-                    typeof currentVariant.finalAmount === "number"
-                      ? currentVariant.finalAmount
-                      : currentVariant.price?.amount,
-                });
+                addToCart(
+                  {
+                    ...product,
+                    selectedVariantId: currentVariant._id,
+                    selectedSku: currentVariant.stock.sku,
+                    selectedMeasure: currentVariant.measure,
+                    selectedMeasureUnit:
+                      currentVariant.measureUnit || undefined, // ✅
+                    selectedColor: currentVariant.color?.name,
+                    price:
+                      typeof currentVariant.finalAmount === "number"
+                        ? currentVariant.finalAmount
+                        : currentVariant.price?.amount,
+                  },
+                  1
+                );
               }}
             >
               {inStock > 0


### PR DESCRIPTION
## Summary
- allow the cart context to accept an optional quantity when adding items and clamp the value to at least one
- ensure ProductCard and ProductDetails pass the quantity when invoking addToCart so the new API is used consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e10b625eb08330ad6100ffcd1d7da6