### PR TITLE
Add quantity selection to product cards

### DIFF
--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -229,6 +229,7 @@
     "discountTimer": "ينتهي قريبًا",
     "dialogDescription": "اختر اللون والمقاس قبل إضافة المنتج إلى السلة.",
     "cancel": "إلغاء",
+    "quantityLabel": "الكمية",
     "inStock": "المتوفر: {{count}}",
     "outOfStock": "غير متوفر حالياً"
   },

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -234,6 +234,7 @@
     "discountTimer": "מסתיים בקרוב",
     "dialogDescription": "בחרו צבע ומידה לפני הוספת המוצר לעגלה.",
     "cancel": "ביטול",
+    "quantityLabel": "כמות",
     "inStock": "זמין במלאי: {{count}}",
     "outOfStock": "אזל מהמלאי"
   },


### PR DESCRIPTION
## Summary
- add quantity selection state to the product card, resetting with variant or dialog changes and clamping to stock levels
- render the quantity input next to desktop add-to-cart and inside the mobile dialog, piping the chosen quantity to cart actions
- provide Arabic and Hebrew translations for the new quantity label

## Testing
- npm run lint *(fails: existing lint violations in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68e10c6075b88330ba8768cdbb70c798