### PR TITLE
Add quantity controls to product details page

### DIFF
--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -211,6 +211,7 @@
       "label": "المتوفر: {{count}}",
       "sku": " • SKU: {{sku}}"
     },
+    "quantityLabel": "الكمية",
     "cta": {
       "addToCart": "إضافة للسلة",
       "outOfStock": "غير متوفر"

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -216,6 +216,7 @@
       "label": "זמין במלאי: {{count}}",
       "sku": " • SKU: {{sku}}"
     },
+    "quantityLabel": "כמות",
     "cta": {
       "addToCart": "הוספה לעגלה",
       "outOfStock": "אזל מהמלאי"


### PR DESCRIPTION
## Summary
- add quantity state to the product details page and reset it when variants change
- clamp the quantity selector to available stock and pass it to the cart CTA
- translate the new quantity label in Arabic and Hebrew locale files

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e10dd9ffb883308543cdaa6148449b