### PR TITLE
Add placeholder quantity support to product card input

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -716,7 +716,12 @@ const ProductCard: React.FC<Props> = ({ product }) => {
         {/* أزرار الديسكتوب — كما هي */}
         <div className="mt-auto flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <QuantityInput quantity={quantity} onChange={handleQuantityChange} />
+            <QuantityInput
+              quantity={quantity}
+              onChange={handleQuantityChange}
+              placeholder="الكمية"
+              placeholderQuantity={1}
+            />
             <Button onClick={addItemToCart} className="flex-1">
               {t("productCard.addToCart")}
             </Button>
@@ -928,6 +933,8 @@ const ProductCard: React.FC<Props> = ({ product }) => {
                   <QuantityInput
                     quantity={quantity}
                     onChange={handleQuantityChange}
+                    placeholder="الكمية"
+                    placeholderQuantity={1}
                   />
                 </div>
 

--- a/client/ama/src/components/common/QuantityInput.tsx
+++ b/client/ama/src/components/common/QuantityInput.tsx
@@ -3,20 +3,32 @@ import React, { useState, useEffect, useRef } from "react";
 interface QuantityInputProps {
   quantity: number;
   onChange: (newQty: number) => void;
+  placeholder?: string;
+  placeholderQuantity?: number;
 }
 
 const QuantityInput: React.FC<QuantityInputProps> = ({
   quantity,
   onChange,
+  placeholder,
+  placeholderQuantity,
 }) => {
+  const effectivePlaceholderQuantity = placeholderQuantity ?? 1;
+  const hasPlaceholderConfig =
+    placeholder !== undefined || placeholderQuantity !== undefined;
+
   const [tempValue, setTempValue] = useState<string>(quantity.toString());
+  const [isDirty, setIsDirty] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (document.activeElement !== inputRef.current) {
       setTempValue(quantity.toString());
+      if (hasPlaceholderConfig) {
+        setIsDirty(quantity !== effectivePlaceholderQuantity);
+      }
     }
-  }, [quantity]);
+  }, [quantity, effectivePlaceholderQuantity, hasPlaceholderConfig]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
@@ -24,17 +36,43 @@ const QuantityInput: React.FC<QuantityInputProps> = ({
     // السماح فقط بالأرقام أو فراغ مؤقت
     if (/^\d*$/.test(val)) {
       setTempValue(val);
+      if (hasPlaceholderConfig) {
+        setIsDirty(val !== "");
+      }
     }
   };
 
   const handleBlur = () => {
-    const parsed = parseInt(tempValue);
+    if (tempValue === "") {
+      if (hasPlaceholderConfig) {
+        onChange(effectivePlaceholderQuantity);
+        setTempValue(effectivePlaceholderQuantity.toString());
+        setIsDirty(false);
+      } else {
+        setTempValue(quantity.toString());
+      }
+      return;
+    }
+
+    const parsed = parseInt(tempValue, 10);
     if (!isNaN(parsed) && parsed >= 1) {
       onChange(parsed);
+      setTempValue(parsed.toString());
+      if (hasPlaceholderConfig) {
+        setIsDirty(parsed !== effectivePlaceholderQuantity);
+      }
     } else {
       setTempValue(quantity.toString()); // إرجاع القيمة الأصلية إذا فشل الإدخال
+      if (hasPlaceholderConfig) {
+        setIsDirty(quantity !== effectivePlaceholderQuantity);
+      }
     }
   };
+
+  const resolvedPlaceholder = placeholder ?? "الكمية";
+  const shouldShowPlaceholder =
+    hasPlaceholderConfig && !isDirty && quantity === effectivePlaceholderQuantity;
+  const displayValue = shouldShowPlaceholder ? "" : tempValue;
 
   return (
     <input
@@ -43,7 +81,8 @@ const QuantityInput: React.FC<QuantityInputProps> = ({
       inputMode="numeric"
       pattern="[0-9]*"
       className="border w-20 px-2 py-1 rounded text-center"
-      value={tempValue}
+      value={displayValue}
+      placeholder={resolvedPlaceholder}
       onChange={handleChange}
       onBlur={handleBlur}
     />


### PR DESCRIPTION
## Summary
- extend the quantity input to support optional placeholders and placeholder quantities
- show the configured placeholder text when the value matches the placeholder quantity and track dirty state
- use the new placeholder behaviour for the product card quantity input so it defaults to the localized placeholder text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20e3240c08330a5009b0cc3cbc5e9