### PR TITLE
Enhance product card add-to-cart feedback

### DIFF
--- a/client/ama/src/components/CartButton.tsx
+++ b/client/ama/src/components/CartButton.tsx
@@ -1,15 +1,51 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { ShoppingCart } from "lucide-react";
 import { useCart } from "@/context/CartContext";
+import clsx from "clsx";
+import { subscribeToCartHighlight } from "@/lib/cartHighlight";
 
 const CartButton: React.FC = () => {
   const { cart } = useCart();
   const count = cart.reduce((sum, item) => sum + item.quantity, 0);
+  const [highlight, setHighlight] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return subscribeToCartHighlight(() => {
+      setHighlight(true);
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = window.setTimeout(() => {
+        setHighlight(false);
+      }, 800);
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
-    <Link to="/cart" className="relative">
-      <ShoppingCart size={28} />
+    <Link
+      to="/cart"
+      className={clsx(
+        "relative inline-flex items-center justify-center transition-transform duration-200",
+        highlight && "scale-110 text-amber-500 drop-shadow-[0_0_12px_rgba(251,191,36,0.45)]"
+      )}
+    >
+      <ShoppingCart
+        size={28}
+        className={clsx(
+          "transition-colors duration-200",
+          highlight && "text-amber-500"
+        )}
+      />
       {count > 0 && (
         <span className="absolute -top-2 -right-2 bg-red-600 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
           {count}

--- a/client/ama/src/lib/cartHighlight.ts
+++ b/client/ama/src/lib/cartHighlight.ts
@@ -1,0 +1,22 @@
+export const CART_HIGHLIGHT_EVENT = "cart:highlight";
+
+export const dispatchCartHighlight = () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(CART_HIGHLIGHT_EVENT));
+};
+
+export const subscribeToCartHighlight = (callback: () => void) => {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const handler = () => {
+    callback();
+  };
+
+  window.addEventListener(CART_HIGHLIGHT_EVENT, handler);
+
+  return () => {
+    window.removeEventListener(CART_HIGHLIGHT_EVENT, handler);
+  };
+};

--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -221,6 +221,8 @@
     "previousImage": "الصورة السابقة",
     "nextImage": "الصورة التالية",
     "addToCart": "إضافة للسلة",
+    "addingToCart": "جاري الإضافة…",
+    "addedToCart": "أُضيفت للسلة",
     "viewDetails": "عرض التفاصيل",
     "sizeLabel": "المقاس",
     "sizesLabel": "المقاسات",

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -226,6 +226,8 @@
     "previousImage": "התמונה הקודמת",
     "nextImage": "התמונה הבאה",
     "addToCart": "הוספה לעגלה",
+    "addingToCart": "מוסיף לעגלה…",
+    "addedToCart": "נוסף לעגלה",
     "viewDetails": "צפה בפרטים",
     "sizeLabel": "מידה",
     "sizesLabel": "מידות",


### PR DESCRIPTION
## Summary
- add transient add-to-cart state handling so the product card can show immediate feedback and prevent rapid re-clicks
- highlight the navbar cart button via a lightweight event whenever an item is added
- localize new feedback messages for Arabic and Hebrew users

## Testing
- npm run lint *(fails: existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e21d25afd08330b4e022db7ad49621