### PR TITLE
Adjust products grid to two columns on mobile

### DIFF
--- a/client/ama/src/pages/Products.tsx
+++ b/client/ama/src/pages/Products.tsx
@@ -967,7 +967,7 @@ const Products: React.FC = () => {
         ) : (
           <>
             {/* ✅ عمودين على الموبايل، 3 أعمدة من md وفوق */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4 md:gap-6 items-start">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4 md:gap-6 items-start">
               {products.map((product) => (
                 <ProductCard key={product._id} product={product} />
               ))}


### PR DESCRIPTION
## Summary
- update the products grid to use two columns by default while keeping existing responsive breakpoints intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e259b498bc83309ab5fb4e45412b69