### PR TITLE
Adjust desktop product card toggle styling

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -593,7 +593,11 @@ const ProductCard: React.FC<Props> = ({ product }) => {
         <button
           type="button"
           onClick={toggleDesktopDetails}
-          className="absolute left-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-600 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 z-40"
+          className={clsx(
+            "absolute top-3 [inset-inline-end:0.75rem] inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-900 shadow-sm transition hover:bg-gray-100 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 z-40",
+            isDesktopDetailsOpen &&
+              "bg-black text-white hover:bg-black border-black shadow-md"
+          )}
           aria-expanded={isDesktopDetailsOpen}
           aria-controls={desktopDetailsId}
           aria-label={


### PR DESCRIPTION
## Summary
- move the desktop product card toggle to the inline-end corner so it remains anchored in both LTR and RTL layouts
- align the desktop toggle styling with the mobile affordance for higher-contrast visuals when opening and closing details

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e262dffb8c83309978a13b17a0cd41