### PR TITLE
Fix ProductCard grid structure for mobile sheet

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -454,7 +454,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
   }
 
   return (
-    <>
+    <div className="contents">
       {/* ============ موبايل (واجهة مبسّطة + كل البطاقة تفتح التفاصيل) ============ */}
       <div
         className="relative border rounded-lg p-2 text-right hover:shadow flex flex-col h-full md:hidden cursor-pointer"
@@ -896,8 +896,8 @@ const ProductCard: React.FC<Props> = ({ product }) => {
         </div>
       </div>
 
-      <div className="md:hidden">
-        {isMobileSheetOpen && (
+      {isMobileSheetOpen && (
+        <div className="md:hidden">
           <div
             className={clsx(
               "mt-2 overflow-hidden rounded-b-lg border border-gray-200 bg-white shadow-xl",
@@ -1171,9 +1171,9 @@ const ProductCard: React.FC<Props> = ({ product }) => {
               </Button>
             </div>
           </div>
-        )}
-      </div>
-    </>
+        </div>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap the ProductCard mobile and desktop views in a single container so the grid only receives one child per product
- render the mobile sheet container only when open to avoid emitting an empty grid item on small screens

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e268436360833092172a1eefbe759d