### PR TITLE
Fix redundant closing in ProductCard portal

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -1268,7 +1268,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
             </div>
           </div>,
           document.body
-        )}
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the duplicate closing from the ProductCard mobile sheet portal so the conditional render closes correctly

## Testing
- npm run build *(fails: Missing script "build" defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e26c55b0548330a191eb5cdff7c089