### PR TITLE
Refine product quick view overlay

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState, useCallback, useRef } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  type ChangeEvent,
+} from "react";
 import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import clsx from "clsx";
@@ -8,8 +15,7 @@ import { getLocalizedText, type LocalizedText } from "@/lib/localized";
 import { getColorLabel } from "@/lib/colors";
 import { useLanguage } from "@/context/LanguageContext";
 import { useTranslation } from "@/i18n";
-import QuantityInput from "@/components/common/QuantityInput";
-import { Loader2, Check, Plus, X } from "lucide-react";
+import { Loader2, Check, Plus, X, ChevronLeft, ChevronRight } from "lucide-react";
 import { dispatchCartHighlight } from "@/lib/cartHighlight";
 
 interface Props {
@@ -58,8 +64,15 @@ const clamp = (n: number, min = 0, max = 100) =>
 const fallbackImg = "https://i.imgur.com/PU1aG4t.jpeg";
 
 /** ✅ يُرجع دائمًا مصفوفة المتغيّرات سواء كانت الاستجابة {items:[]} أو [] مباشرة */
-function normalizeVariantsResponse(data: any): Variant[] {
-  if (data && Array.isArray(data.items)) return data.items as Variant[];
+function normalizeVariantsResponse(data: unknown): Variant[] {
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "items" in data &&
+    Array.isArray((data as { items?: unknown }).items)
+  ) {
+    return (data as { items: Variant[] }).items ?? [];
+  }
   if (Array.isArray(data)) return data as Variant[];
   return [];
 }
@@ -94,6 +107,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
   // تفاصيل البطاقة
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [quantity, setQuantity] = useState(1);
+  const [quantityInputValue, setQuantityInputValue] = useState("1");
   const [isAdding, setIsAdding] = useState(false);
   const [justAdded, setJustAdded] = useState(false);
   const mobileCardRef = useRef<HTMLDivElement | null>(null);
@@ -103,183 +117,108 @@ const ProductCard: React.FC<Props> = ({ product }) => {
     () => `product-details-${product._id}`,
     [product._id]
   );
-  const closeDetails = useCallback(() => {
-    setIsDetailsOpen(false);
-  }, []);
   const toggleDetails = useCallback(() => {
     setIsDetailsOpen((prev) => !prev);
   }, []);
 
-  const DetailsOverlay = ({ className }: { className?: string }) => (
-    <div
-      className={clsx(
-        "absolute inset-0 z-30 pointer-events-none",
-        className
-      )}
-    >
+  const DetailsOverlay = ({ className }: { className?: string }) => {
+    const decreaseDisabled = quantity <= 1;
+    const increaseDisabled =
+      typeof maxSelectableQuantity === "number" &&
+      quantity >= maxSelectableQuantity;
+
+    return (
       <div
-        className="absolute inset-0 rounded-lg bg-black/10 backdrop-blur-sm pointer-events-auto"
-        onClick={closeDetails}
-        aria-hidden="true"
-      />
-      <div className="relative z-10 flex h-full flex-col overflow-hidden rounded-lg bg-white shadow-2xl ring-1 ring-black/10 pointer-events-auto animate-in fade-in slide-in-from-bottom duration-300 ease-out">
+        className={clsx(
+          "absolute inset-x-0 bottom-0 z-30 pointer-events-none",
+          className
+        )}
+      >
         <div
-          id={detailsPanelId}
-          className="flex flex-1 flex-col gap-1.5 overflow-y-auto p-4"
+          className="pointer-events-auto overflow-hidden rounded-t-lg bg-white shadow-2xl ring-1 ring-black/10 animate-in fade-in slide-in-from-bottom duration-300 ease-out"
+          onClick={(event) => event.stopPropagation()}
         >
-          {productDescription && (
-            <p className="text-sm leading-6 text-gray-600">
-              {productDescription}
-            </p>
-          )}
-
-          {measuresFromVariants.filter((m) => !isUnified(m.label)).length >
-            0 && (
-            <div>
-              <div className="mb-1 text-sm font-medium">
-                {t("productCard.sizeLabel")}
-              </div>
-              <div className="flex flex-wrap justify-end gap-2">
-                {measuresFromVariants
-                  .filter((m) => !isUnified(m.label))
-                  .map((m) => {
-                    const labelWithUnit = m.unit
-                      ? `${m.label} ${m.unit}`
-                      : m.label;
-                    return (
-                      <button
-                        key={m.slug}
-                        title={labelWithUnit}
-                        onClick={() => {
-                          setSelectedMeasure(m.slug);
-                          setCurrentImage(0);
-                        }}
-                        className={clsx(
-                          "px-3 py-1 text-sm rounded border transition",
-                          selectedMeasure === m.slug
-                            ? "border-black font-bold"
-                            : "border-gray-300"
-                        )}
-                      >
-                        {labelWithUnit}
-                      </button>
-                    );
-                  })}
-              </div>
-            </div>
-          )}
-
-          {allColorsFromVariants.filter((c) => !isUnified(c.name)).length >
-            0 && (
-            <div>
-              <div className="mb-1 text-sm font-medium">
-                {t("productCard.colorLabel")}
-              </div>
-              <div className="flex flex-wrap justify-end gap-2">
-                {allColorsFromVariants
-                  .filter((c) => !isUnified(c.name))
-                  .map((c) => {
-                    const isAvailable =
-                      selectedMeasure &&
-                      availableColorSlugsForSelectedMeasure.has(c.slug);
-
-                    return (
-                      <button
-                        key={c.slug}
-                        title={c.name}
-                        onClick={() => {
-                          if (!isAvailable) return;
-                          setSelectedColor(c.slug);
-                          setCurrentImage(0);
-                        }}
-                        disabled={!isAvailable}
-                        className={clsx(
-                          "px-3 py-1 text-sm rounded border transition",
-                          selectedColor === c.slug && isAvailable
-                            ? "border-black font-bold"
-                            : "border-gray-300",
-                          !isAvailable && "opacity-40 cursor-not-allowed"
-                        )}
-                      >
-                        {c.name}
-                      </button>
-                    );
-                  })}
-              </div>
-            </div>
-          )}
-
-          {currentVariant && (
-            <div className="text-sm text-gray-600">
-              {currentVariant.stock?.inStock > 0
-                ? t("productCard.inStock", {
-                    count: currentVariant.stock?.inStock,
-                  })
-                : t("productCard.outOfStock")}
-            </div>
-          )}
-
-          {showDiscountTimer &&
-            progressPct !== null &&
-            timeLeftMs !== null && (
-              <div>
-                <div
-                  className="w-full h-2 rounded-full bg-gray-200 overflow-hidden"
-                  role="progressbar"
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={Math.round(progressPct)}
-                  title={t("productCard.discountTimerTitle")}
-                >
-                  <div
-                    className="h-full bg-red-600 transition-all duration-500"
-                    style={{ width: `${progressPct}%` }}
-                  />
-                </div>
-                <div className="mt-1 text-xs text-red-700 font-semibold text-right">
-                  {t("productCard.discountTimer")}
-                </div>
-              </div>
+          <div
+            id={detailsPanelId}
+            className="flex max-h-[min(26rem,80vh)] flex-col gap-4 overflow-y-auto p-4"
+          >
+            {productDescription && (
+              <p className="text-sm leading-6 text-gray-600">
+                {productDescription}
+              </p>
             )}
 
-          <div className="mt-auto flex flex-col gap-1.5">
-            <div className="flex items-center gap-1.5">
-              <QuantityInput
-                quantity={quantity}
-                onChange={handleQuantityChange}
-                placeholder="الكمية"
-                placeholderQuantity={1}
-              />
-              <Button
-                onClick={() => {
-                  void addItemToCart();
-                }}
-                className={clsx(
-                  "flex-1 transition-transform duration-200",
-                  justAdded &&
-                    "scale-[1.02] ring-2 ring-green-400 ring-offset-2 ring-offset-white bg-green-600 text-white",
-                  isAdding && "opacity-80 cursor-not-allowed",
-                  !isAdding && !justAdded && "hover:scale-[1.01]"
-                )}
-                disabled={isAdding || isVariantUnavailable}
-              >
-                {justAdded ? (
-                  <span className="flex items-center justify-center gap-1.5">
-                    <Check className="h-4 w-4" />
-                    {t("productCard.addedToCart")}
-                  </span>
-                ) : isVariantUnavailable ? (
-                  t("productCard.outOfStock")
-                ) : isAdding ? (
-                  <span className="flex items-center justify-center gap-1.5">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    {t("productCard.addingToCart")}
-                  </span>
-                ) : (
-                  t("productCard.addToCart")
-                )}
-              </Button>
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-gray-900">
+                {t("productCard.quantityLabel")}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={decrementQuantity}
+                  disabled={decreaseDisabled}
+                  aria-label={t("productCard.decreaseQuantity")}
+                  className={clsx(
+                    "inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-900 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black",
+                    decreaseDisabled && "opacity-50 cursor-not-allowed"
+                  )}
+                >
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={quantityInputValue}
+                  onChange={handleQuantityInputChange}
+                  placeholder="1"
+                  className="h-10 w-full flex-1 rounded-full border border-gray-300 bg-white px-4 text-center text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+                />
+                <button
+                  type="button"
+                  onClick={incrementQuantity}
+                  disabled={increaseDisabled}
+                  aria-label={t("productCard.increaseQuantity")}
+                  className={clsx(
+                    "inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-900 transition hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black",
+                    increaseDisabled && "opacity-50 cursor-not-allowed"
+                  )}
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
             </div>
+
+            <Button
+              onClick={() => {
+                void addItemToCart();
+              }}
+              className={clsx(
+                "w-full transition-transform duration-200",
+                justAdded &&
+                  "scale-[1.02] ring-2 ring-green-400 ring-offset-2 ring-offset-white bg-green-600 text-white",
+                isAdding && "opacity-80 cursor-not-allowed",
+                !isAdding && !justAdded && "hover:scale-[1.01]"
+              )}
+              disabled={isAdding || isVariantUnavailable}
+            >
+              {justAdded ? (
+                <span className="flex items-center justify-center gap-1.5">
+                  <Check className="h-4 w-4" />
+                  {t("productCard.addedToCart")}
+                </span>
+              ) : isVariantUnavailable ? (
+                t("productCard.outOfStock")
+              ) : isAdding ? (
+                <span className="flex items-center justify-center gap-1.5">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {t("productCard.addingToCart")}
+                </span>
+              ) : (
+                t("productCard.addToCart")
+              )}
+            </Button>
+
             <Link to={`/products/${product._id}`}>
               <Button variant="secondary" className="w-full">
                 {t("productCard.viewDetails")}
@@ -288,8 +227,133 @@ const ProductCard: React.FC<Props> = ({ product }) => {
           </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  };
+
+  const VariantControls = ({ className }: { className?: string }) => {
+    const filteredMeasures = measuresFromVariants.filter(
+      (m) => !isUnified(m.label)
+    );
+    const filteredColors = allColorsFromVariants.filter(
+      (c) => !isUnified(c.name)
+    );
+
+    const hasSizes = filteredMeasures.length > 0;
+    const hasColors = filteredColors.length > 0;
+    const showStock = Boolean(currentVariant);
+    const showTimer =
+      showDiscountTimer && progressPct !== null && timeLeftMs !== null;
+
+    if (!hasSizes && !hasColors && !showStock && !showTimer) {
+      return null;
+    }
+
+    return (
+      <div
+        className={clsx("flex flex-col gap-3", className)}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {hasSizes && (
+          <div>
+            <div className="mb-1 text-sm font-medium">
+              {t("productCard.sizeLabel")}
+            </div>
+            <div className="flex flex-wrap justify-end gap-2">
+              {filteredMeasures.map((m) => {
+                const labelWithUnit = m.unit ? `${m.label} ${m.unit}` : m.label;
+                return (
+                  <button
+                    key={m.slug}
+                    title={labelWithUnit}
+                    onClick={() => {
+                      setSelectedMeasure(m.slug);
+                      setCurrentImage(0);
+                    }}
+                    className={clsx(
+                      "rounded border px-3 py-1 text-sm transition",
+                      selectedMeasure === m.slug
+                        ? "border-black font-bold"
+                        : "border-gray-300"
+                    )}
+                  >
+                    {labelWithUnit}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {hasColors && (
+          <div>
+            <div className="mb-1 text-sm font-medium">
+              {t("productCard.colorLabel")}
+            </div>
+            <div className="flex flex-wrap justify-end gap-2">
+              {filteredColors.map((c) => {
+                const isAvailable =
+                  selectedMeasure &&
+                  availableColorSlugsForSelectedMeasure.has(c.slug);
+
+                return (
+                  <button
+                    key={c.slug}
+                    title={c.name}
+                    onClick={() => {
+                      if (!isAvailable) return;
+                      setSelectedColor(c.slug);
+                      setCurrentImage(0);
+                    }}
+                    disabled={!isAvailable}
+                    className={clsx(
+                      "rounded border px-3 py-1 text-sm transition",
+                      selectedColor === c.slug && isAvailable
+                        ? "border-black font-bold"
+                        : "border-gray-300",
+                      !isAvailable && "cursor-not-allowed opacity-40"
+                    )}
+                  >
+                    {c.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {showStock && currentVariant && (
+          <div className="text-sm text-gray-600">
+            {currentVariant.stock?.inStock > 0
+              ? t("productCard.inStock", {
+                  count: currentVariant.stock?.inStock,
+                })
+              : t("productCard.outOfStock")}
+          </div>
+        )}
+
+        {showTimer && (
+          <div>
+            <div
+              className="h-2 w-full overflow-hidden rounded-full bg-gray-200"
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(progressPct ?? 0)}
+              title={t("productCard.discountTimerTitle")}
+            >
+              <div
+                className="h-full bg-red-600 transition-all duration-500"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <div className="mt-1 text-xs font-semibold text-red-700 text-right">
+              {t("productCard.discountTimer")}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
 
   useEffect(() => {
     return () => {
@@ -298,39 +362,6 @@ const ProductCard: React.FC<Props> = ({ product }) => {
       }
     };
   }, []);
-
-  useEffect(() => {
-    if (!isDetailsOpen) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target as Node;
-      const desktopEl = desktopCardRef.current;
-      const mobileEl = mobileCardRef.current;
-
-      if (
-        (desktopEl && desktopEl.contains(target)) ||
-        (mobileEl && mobileEl.contains(target))
-      ) {
-        return;
-      }
-
-      closeDetails();
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeDetails();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isDetailsOpen, closeDetails]);
 
   // جلب المتغيّرات
   useEffect(() => {
@@ -420,6 +451,11 @@ const ProductCard: React.FC<Props> = ({ product }) => {
 
   const currentVariantId = currentVariant?._id ?? "no-variant";
 
+  const maxSelectableQuantity = useMemo(() => {
+    const maxQty = currentVariant?.stock?.inStock;
+    return typeof maxQty === "number" && maxQty > 0 ? maxQty : null;
+  }, [currentVariant?.stock?.inStock]);
+
   const displayedImages = useMemo(() => {
     const variantColorImages =
       currentVariant?.color?.images?.filter(Boolean) ?? [];
@@ -450,15 +486,24 @@ const ProductCard: React.FC<Props> = ({ product }) => {
     setCurrentImage(0);
   }, [displayedImages]);
 
-  useEffect(() => {
+  const resetQuantityState = useCallback(() => {
     setQuantity(1);
-  }, [currentVariantId]);
+    setQuantityInputValue("1");
+  }, []);
+
+  useEffect(() => {
+    resetQuantityState();
+  }, [currentVariantId, resetQuantityState]);
+
+  useEffect(() => {
+    resetQuantityState();
+  }, [displayedImages, resetQuantityState]);
 
   useEffect(() => {
     if (!isDetailsOpen) {
-      setQuantity(1);
+      resetQuantityState();
     }
-  }, [isDetailsOpen]);
+  }, [isDetailsOpen, resetQuantityState]);
 
   // الأسعار/الخصم
   const variantFinal = currentVariant?.finalAmount;
@@ -538,18 +583,58 @@ const ProductCard: React.FC<Props> = ({ product }) => {
   const arrowIcon = "pointer-events-none select-none";
 
   // إضافة للسلة
-  const handleQuantityChange = useCallback(
-    (newQty: number) => {
-      const maxQty = currentVariant?.stock?.inStock;
+  const setQuantityWithBounds = useCallback(
+    (value: number) => {
       const safeQty = clamp(
-        newQty,
+        value,
         1,
-        typeof maxQty === "number" && maxQty > 0 ? maxQty : newQty
+        typeof maxSelectableQuantity === "number"
+          ? maxSelectableQuantity
+          : value
       );
       setQuantity(safeQty);
+      setQuantityInputValue(safeQty.toString());
     },
-    [currentVariant?.stock?.inStock]
+    [maxSelectableQuantity]
   );
+
+  const handleQuantityInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      if (!/^\d*$/.test(value)) return;
+
+      setQuantityInputValue(value);
+
+      if (value === "") {
+        setQuantity(1);
+        return;
+      }
+
+      const parsed = parseInt(value, 10);
+      if (Number.isNaN(parsed)) return;
+
+      const safeQty = clamp(
+        parsed,
+        1,
+        typeof maxSelectableQuantity === "number"
+          ? maxSelectableQuantity
+          : parsed
+      );
+      setQuantity(safeQty);
+      if (safeQty !== parsed) {
+        setQuantityInputValue(safeQty.toString());
+      }
+    },
+    [maxSelectableQuantity]
+  );
+
+  const incrementQuantity = useCallback(() => {
+    setQuantityWithBounds(quantity + 1);
+  }, [quantity, setQuantityWithBounds]);
+
+  const decrementQuantity = useCallback(() => {
+    setQuantityWithBounds(quantity - 1);
+  }, [quantity, setQuantityWithBounds]);
 
   const addItemToCart = useCallback(async () => {
     if (isAdding) return false;
@@ -777,6 +862,8 @@ const ProductCard: React.FC<Props> = ({ product }) => {
               )}
             </div>
           </div>
+
+          <VariantControls className="mt-3" />
         </div>
 
         {isDetailsOpen && <DetailsOverlay className="flex md:hidden" />}
@@ -886,6 +973,8 @@ const ProductCard: React.FC<Props> = ({ product }) => {
               {product.subCategory}
             </p>
           )}
+
+          <VariantControls className="mt-2" />
 
           <div className="mt-auto flex items-center justify-between gap-2 pt-3">
             <div className="flex flex-col items-end text-right">

--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -235,6 +235,8 @@
     "dialogDescription": "اختر اللون والمقاس قبل إضافة المنتج إلى السلة.",
     "cancel": "إلغاء",
     "quantityLabel": "الكمية",
+    "increaseQuantity": "زيادة الكمية",
+    "decreaseQuantity": "تقليل الكمية",
     "inStock": "المتوفر: {{count}}",
     "outOfStock": "غير متوفر حالياً"
   },

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -240,6 +240,8 @@
     "dialogDescription": "בחרו צבע ומידה לפני הוספת המוצר לעגלה.",
     "cancel": "ביטול",
     "quantityLabel": "כמות",
+    "increaseQuantity": "הגדל כמות",
+    "decreaseQuantity": "הפחת כמות",
     "inStock": "זמין במלאי: {{count}}",
     "outOfStock": "אזל מהמלאי"
   },


### PR DESCRIPTION
## Summary
- restyle the quick-view overlay to match the card width, keep the product description visible, and replace the quantity picker with arrow buttons plus manual input
- keep the size and color selectors on the product card itself via a shared variant controls block for mobile and desktop layouts
- add localized labels for the new quantity control buttons

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e35f58751c83308b10768a44b7d59e