### PR TITLE
Animate expanded product panel

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -438,10 +438,10 @@ const ProductCard: React.FC<Props> = ({ product }) => {
   const ExpandedPanel = ({ className }: { className?: string }) => (
     <div
       className={clsx(
-        "absolute inset-x-0 bottom-0 z-30 flex flex-col gap-4 rounded-t-2xl bg-white p-4 shadow-xl transition-all duration-300",
+        "absolute inset-x-0 bottom-0 z-30 flex flex-col gap-4 rounded-lg bg-white p-4 shadow-xl transition-[transform,opacity] duration-300 will-change-transform",
         isDetailsOpen
-          ? "translate-y-0 opacity-100 pointer-events-auto"
-          : "translate-y-full opacity-0 pointer-events-none",
+          ? "translate-y-0 opacity-100 pointer-events-auto ease-out"
+          : "translate-y-full opacity-0 pointer-events-none ease-in",
         className
       )}
       onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Summary
- add easing-based transform transition so the expanded panel slides smoothly into view
- align the expanded panel border radius with the surrounding product card radius for consistent styling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e37163ef308330967f8b3560cb792e