### PR TITLE
Normalize product category selections

### DIFF
--- a/client/ama/src/pages/Products.tsx
+++ b/client/ama/src/pages/Products.tsx
@@ -98,6 +98,17 @@ function slugifyLabel(value: string): string {
     .replace(/[^\p{L}\p{N}-]+/gu, "");
 }
 
+function normalizeArabic(input: string): string {
+  if (!input) return "";
+  let s = input.trim();
+
+  s = s.replace(/[\u064B-\u0652\u0670\u0640]/g, "");
+  s = s.replace(/[أإآ]/g, "ا").replace(/ى/g, "ي").replace(/ة/g, "ه");
+  s = s.replace(/\s+/g, " ").toLowerCase();
+
+  return s;
+}
+
 const Products: React.FC = () => {
   const { user, token } = useAuth();
   const canUseOwnership = user?.role === "admin" || user?.role === "dealer";
@@ -154,6 +165,61 @@ const Products: React.FC = () => {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState<number>(-1);
 
+  const normalizedMainCategories = useMemo(() => {
+    const source = categoryMenu.length ? categoryMenu : categoryGroups;
+    const map = new Map<string, string>();
+
+    const register = (key: string, value: string) => {
+      const normalizedKey = key.trim();
+      if (!normalizedKey) return;
+      if (!map.has(normalizedKey)) {
+        map.set(normalizedKey, value);
+      }
+    };
+
+    for (const group of source) {
+      const { mainCategory } = group;
+      register(mainCategory, mainCategory);
+      register(normalizeArabic(mainCategory), mainCategory);
+      register(slugifyLabel(mainCategory), mainCategory);
+    }
+
+    return map;
+  }, [categoryMenu, categoryGroups]);
+
+  const normalizedSubCategories = useMemo(() => {
+    const source = categoryMenu.length ? categoryMenu : categoryGroups;
+    const outer = new Map<string, Map<string, string>>();
+
+    const register = (
+      container: Map<string, string>,
+      key: string,
+      value: string
+    ) => {
+      const normalizedKey = key.trim();
+      if (!normalizedKey) return;
+      if (!container.has(normalizedKey)) {
+        container.set(normalizedKey, value);
+      }
+    };
+
+    for (const group of source) {
+      const mainKey = normalizeArabic(group.mainCategory);
+      if (!outer.has(mainKey)) {
+        outer.set(mainKey, new Map());
+      }
+      const inner = outer.get(mainKey)!;
+
+      for (const sub of group.subCategories) {
+        register(inner, sub, sub);
+        register(inner, normalizeArabic(sub), sub);
+        register(inner, slugifyLabel(sub), sub);
+      }
+    }
+
+    return outer;
+  }, [categoryMenu, categoryGroups]);
+
   const translateCategoryLabel = useCallback(
     (value: string, type: "main" | "sub") => {
       if (!value) return value;
@@ -189,6 +255,42 @@ const Products: React.FC = () => {
     setSelectedMainCategory((prev) => (prev === category ? prev : category));
     setSelectedSubCategory((prev) => (prev === sub ? prev : sub));
   }, [location.search]);
+
+  useEffect(() => {
+    if (!selectedMainCategory) return;
+
+    const normalizedKey = normalizeArabic(selectedMainCategory);
+    const canonical =
+      normalizedMainCategories.get(normalizedKey) ??
+      normalizedMainCategories.get(slugifyLabel(selectedMainCategory)) ??
+      normalizedMainCategories.get(selectedMainCategory.trim());
+
+    if (canonical && canonical !== selectedMainCategory) {
+      setSelectedMainCategory(canonical);
+    }
+  }, [selectedMainCategory, normalizedMainCategories]);
+
+  useEffect(() => {
+    if (!selectedMainCategory || !selectedSubCategory) return;
+
+    const mainKey = normalizeArabic(selectedMainCategory);
+    const subMap = normalizedSubCategories.get(mainKey);
+    if (!subMap) return;
+
+    const normalizedSub = normalizeArabic(selectedSubCategory);
+    const canonical =
+      subMap.get(normalizedSub) ??
+      subMap.get(slugifyLabel(selectedSubCategory)) ??
+      subMap.get(selectedSubCategory.trim());
+
+    if (canonical && canonical !== selectedSubCategory) {
+      setSelectedSubCategory(canonical);
+    }
+  }, [
+    selectedMainCategory,
+    selectedSubCategory,
+    normalizedSubCategories,
+  ]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
## Summary
- normalize Arabic category names and build lookup maps on the products page
- synchronize selected main and sub categories from the URL with canonical category values so navigation from the home page activates the correct filters

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f489b11bb48330b0b7f2454c848282