### PR TITLE
Disable stock adjustments and hide inventory counts

### DIFF
--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -208,7 +208,8 @@
       }
     },
     "availability": {
-      "label": "المتوفر: {{count}}",
+      "available": "متوفر حالياً",
+      "out": "غير متوفر حالياً",
       "sku": " • SKU: {{sku}}"
     },
     "quantityLabel": "الكمية",
@@ -233,7 +234,7 @@
     "dialogDescription": "اختر اللون والمقاس قبل إضافة المنتج إلى السلة.",
     "cancel": "إلغاء",
     "quantityLabel": "الكمية",
-    "inStock": "المتوفر: {{count}}",
+    "inStock": "متوفر",
     "outOfStock": "غير متوفر حالياً"
   },
   "common": {

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -213,7 +213,8 @@
       }
     },
     "availability": {
-      "label": "זמין במלאי: {{count}}",
+      "available": "זמין במלאי",
+      "out": "אזל מהמלאי",
       "sku": " • SKU: {{sku}}"
     },
     "quantityLabel": "כמות",
@@ -238,7 +239,7 @@
     "dialogDescription": "בחרו צבע ומידה לפני הוספת המוצר לעגלה.",
     "cancel": "ביטול",
     "quantityLabel": "כמות",
-    "inStock": "זמין במלאי: {{count}}",
+    "inStock": "זמין במלאי",
     "outOfStock": "אזל מהמלאי"
   },
   "common": {

--- a/server/index.js
+++ b/server/index.js
@@ -117,6 +117,7 @@ const Order = require("./models/Order");
 const Variant = require("./models/Variant");
 const Product = require("./models/Product");
 const { prepareLahzaPaymentUpdate, verifyLahzaTransaction } = require("./utils/lahza");
+const { isStockTrackingEnabled } = require("./utils/stock");
 
 function getClientIp(req) {
   const xff = req.headers["x-forwarded-for"];
@@ -134,6 +135,9 @@ function getClientIp(req) {
 }
 
 async function decrementStockByOrderItems(items = []) {
+  if (!isStockTrackingEnabled()) {
+    return;
+  }
   await Promise.all(
     (items || []).map((ci) =>
       Variant.updateOne(

--- a/server/utils/stock.js
+++ b/server/utils/stock.js
@@ -1,0 +1,86 @@
+const PRIVILEGED_STOCK_ROLES = new Set(["admin", "dealer"]);
+
+function normalizeFlag(value) {
+  if (value == null) return "";
+  return String(value).trim().toLowerCase();
+}
+
+function parseBooleanFlag(value, defaultValue) {
+  if (value == null) return defaultValue;
+  const normalized = normalizeFlag(value);
+  if (!normalized) return defaultValue;
+  if (["1", "true", "yes", "on", "enable", "enabled"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off", "disable", "disabled"].includes(normalized)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+const STOCK_TRACKING_ENABLED = parseBooleanFlag(
+  process.env.STOCK_TRACKING_ENABLED,
+  false
+);
+
+function isStockTrackingEnabled() {
+  return STOCK_TRACKING_ENABLED;
+}
+
+function canRoleViewStock(role) {
+  if (!role) return false;
+  const normalized = normalizeFlag(role);
+  return PRIVILEGED_STOCK_ROLES.has(normalized);
+}
+
+function sanitizeVariantForRole(variant, role) {
+  if (!variant) return variant;
+  if (canRoleViewStock(role)) return variant;
+
+  const sanitized = { ...variant };
+
+  if (sanitized.stock && typeof sanitized.stock === "object") {
+    const stock = { ...sanitized.stock };
+    if (Object.prototype.hasOwnProperty.call(stock, "inStock")) {
+      delete stock.inStock;
+    }
+    sanitized.stock = stock;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(sanitized, "totalStock")) {
+    delete sanitized.totalStock;
+  }
+
+  return sanitized;
+}
+
+function sanitizeVariantListForRole(list, role) {
+  if (!Array.isArray(list)) return [];
+  return list.map((variant) => sanitizeVariantForRole(variant, role));
+}
+
+function sanitizeProductForRole(product, role) {
+  if (!product) return product;
+  if (canRoleViewStock(role)) return product;
+
+  if (!Object.prototype.hasOwnProperty.call(product, "totalStock")) {
+    return product;
+  }
+
+  const { totalStock, ...rest } = product;
+  return rest;
+}
+
+function sanitizeProductListForRole(list, role) {
+  if (!Array.isArray(list)) return [];
+  return list.map((product) => sanitizeProductForRole(product, role));
+}
+
+module.exports = {
+  isStockTrackingEnabled,
+  canRoleViewStock,
+  sanitizeVariantForRole,
+  sanitizeVariantListForRole,
+  sanitizeProductForRole,
+  sanitizeProductListForRole,
+};


### PR DESCRIPTION
## Summary
- add a reusable stock utility to gate quantity tracking and sanitize responses for non-privileged users
- skip automatic inventory decrements when stock tracking is disabled and guard the manual reserve endpoint
- hide stock counts in public product/variant responses and update the client UI and translations to remove quantity displays while keeping admin workflows intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f498d583788330bb800b241e920a95