### PR TITLE
Treat client inventory as unlimited

### DIFF
--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -318,35 +318,15 @@ const ProductCard: React.FC<Props> = ({ product }) => {
   const arrowIcon = "pointer-events-none select-none";
 
   // إضافة للسلة
-  const handleQuantityChange = useCallback(
-    (newQty: number) => {
-      const maxQty = currentVariant?.stock?.inStock;
-      const safeQty = clamp(
-        newQty,
-        1,
-        typeof maxQty === "number" && maxQty > 0 ? maxQty : newQty
-      );
-      setQuantity(safeQty);
-            setQuantityInput(String(safeQty));
-
-    },
-    [currentVariant?.stock?.inStock]
-  );
-
-  const maxAvailableQuantity = useMemo(() => {
-    const maxQty = currentVariant?.stock?.inStock;
-    if (typeof maxQty === "number" && maxQty > 0) {
-      return maxQty;
-    }
-    return undefined;
-  }, [currentVariant?.stock?.inStock]);
+  const handleQuantityChange = useCallback((newQty: number) => {
+    const safeQty = Math.max(1, Math.min(Number.isFinite(newQty) ? newQty : 1, 999));
+    setQuantity(safeQty);
+    setQuantityInput(String(safeQty));
+  }, []);
 
   const canIncreaseQuantity = useMemo(() => {
-    if (typeof maxAvailableQuantity === "number") {
-      return quantity < maxAvailableQuantity;
-    }
-    return true;
-  }, [quantity, maxAvailableQuantity]);
+    return quantity < 999;
+  }, [quantity]);
 
   const canDecreaseQuantity = quantity > 1;
 
@@ -409,7 +389,6 @@ const ProductCard: React.FC<Props> = ({ product }) => {
 
       if (variants.length > 0) {
         if (!currentVariant) return false;
-        if ((currentVariant.stock?.inStock ?? 0) <= 0) return false;
 
         const itemForCart = {
           ...product,
@@ -424,12 +403,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
               ? currentVariant.finalAmount
               : currentVariant.price?.amount ?? product.price ?? 0,
         };
-        const maxQty = currentVariant.stock?.inStock;
-        const finalQuantity =
-          typeof maxQty === "number" && maxQty > 0
-            ? clamp(effectiveQuantity, 1, maxQty)
-            : effectiveQuantity;
-        addToCart(itemForCart, finalQuantity);
+        addToCart(itemForCart, effectiveQuantity);
         added = true;
       } else {
         const productForCart = {
@@ -470,9 +444,7 @@ const ProductCard: React.FC<Props> = ({ product }) => {
     selectedColor,
   ]);
 
-  const isVariantUnavailable =
-    variants.length > 0 &&
-    (!currentVariant || (currentVariant.stock?.inStock ?? 0) <= 0);
+  const isVariantUnavailable = variants.length > 0 && !currentVariant;
 
   // سكيليتون
   if (vLoading) {

--- a/client/ama/src/pages/ProductDetails.tsx
+++ b/client/ama/src/pages/ProductDetails.tsx
@@ -279,22 +279,16 @@ const ProductDetails: React.FC = () => {
 
   const finalAmount = currentVariant?.finalAmount;
   const compareAt = currentVariant?.displayCompareAt ?? null;
-  const inStock = currentVariant?.stock?.inStock ?? 0;
-
   const handleQuantityChange = (newQty: number) => {
     setQuantity((prev) => {
       const desired = Number.isFinite(newQty) ? newQty : prev;
-      if (!currentVariant) return Math.max(1, desired);
-      const max = currentVariant.stock?.inStock ?? 0;
-      if (max <= 0) return 1;
-      return clamp(desired, 1, max);
+      return Math.max(1, desired);
     });
   };
 
-  const isQuantityValid =
-    !!currentVariant && inStock > 0 && quantity >= 1 && quantity <= inStock;
+  const isQuantityValid = !!currentVariant && quantity >= 1;
 
-  const isCtaDisabled = !currentVariant || inStock <= 0 || !isQuantityValid;
+  const isCtaDisabled = !currentVariant || !isQuantityValid;
 
   const discountPercent =
     typeof finalAmount === "number" &&
@@ -515,17 +509,6 @@ const ProductDetails: React.FC = () => {
                 </div>
               )}
 
-            {currentVariant && (
-              <p className="text-sm text-gray-600 mb-6">
-                {t("productDetails.availability.label", { count: inStock })}
-                {currentVariant.stock?.sku
-                  ? t("productDetails.availability.sku", {
-                      sku: currentVariant.stock.sku,
-                    })
-                  : ""}
-              </p>
-            )}
-
             <div className="flex items-end gap-4 mt-6">
               <div className="flex flex-col gap-2 text-right">
                 <label className="text-sm font-medium">
@@ -558,9 +541,7 @@ const ProductDetails: React.FC = () => {
                   );
                 }}
               >
-              {inStock > 0
-                ? t("productDetails.cta.addToCart")
-                : t("productDetails.cta.outOfStock")}
+              {t("productDetails.cta.addToCart")}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove client-side stock constraints when selecting product variants so quantities are no longer limited by backend inventory
- hide product availability counts on the details page and keep the add-to-cart button active whenever a variant is selected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4a056ca64833091a6dfd334c9a641