### PR TITLE
Add admin-protected order deletion endpoint

### DIFF
--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -897,6 +897,28 @@ router.get("/user/:userId/order/:orderId", verifyToken, async (req, res) => {
   }
 });
 
+/* ======================= حذف طلب (أدمن) ======================= */
+router.delete("/:id", verifyToken, isAdmin, async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({ message: "معرّف الطلب غير صالح" });
+    }
+
+    const deleted = await Order.findByIdAndDelete(id).lean();
+
+    if (!deleted) {
+      return res.status(404).json({ message: "الطلب غير موجود" });
+    }
+
+    return res.json({ message: "تم حذف الطلب", order: deleted });
+  } catch (err) {
+    console.error("DELETE /api/orders/:id error:", err);
+    return res.status(500).json({ message: "فشل حذف الطلب" });
+  }
+});
+
 /* ======================= كل الطلبات (أدمن) ======================= */
 router.get("/", verifyToken, isAdmin, async (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add an admin-only DELETE /api/orders/:id endpoint to remove orders
- validate ObjectId input and return informative responses when deleting orders

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4a27a29f8833092e22fbc0151178a