### PR TITLE
Add admin notifications workflow

### DIFF
--- a/client/ama/src/pages/Account.tsx
+++ b/client/ama/src/pages/Account.tsx
@@ -7,6 +7,15 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
 import axios from "axios";
 
+type NotificationItem = {
+  _id: string;
+  title: string;
+  message: string;
+  target: "all" | "user";
+  createdAt: string;
+  isRead?: boolean;
+};
+
 const statusLabel = (s: string) => {
   switch (s) {
     case "waiting_confirmation":
@@ -30,6 +39,11 @@ const Account: React.FC = () => {
   const { user, logout, loading, token } = useAuth();
   const navigate = useNavigate();
   const [orders, setOrders] = useState<any[]>([]);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [notificationsLoading, setNotificationsLoading] = useState(false);
+  const [notificationsError, setNotificationsError] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     if (!loading && !user) {
@@ -37,6 +51,31 @@ const Account: React.FC = () => {
     }
 
     if (user && token) {
+      setNotificationsLoading(true);
+      setNotificationsError(null);
+      let cancelled = false;
+
+      axios
+        .get(`${import.meta.env.VITE_API_URL}/api/notifications/my`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+        .then((res) => {
+          if (cancelled) return;
+          const list = Array.isArray(res.data) ? res.data : [];
+          setNotifications(list);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          console.error("فشل في جلب الإشعارات", err);
+          setNotificationsError("تعذّر جلب الإشعارات حاليًا");
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setNotificationsLoading(false);
+        });
+
       axios
         .get(`${import.meta.env.VITE_API_URL}/api/orders/user/${user._id}`, {
           headers: {
@@ -45,8 +84,35 @@ const Account: React.FC = () => {
         })
         .then((res) => setOrders(res.data))
         .catch((err) => console.error("فشل في جلب الطلبات", err));
+
+      return () => {
+        cancelled = true;
+      };
     }
   }, [user, loading, navigate, token]);
+
+  const handleMarkAsRead = async (notificationId: string) => {
+    if (!token) return;
+    try {
+      await axios.patch(
+        `${import.meta.env.VITE_API_URL}/api/notifications/${notificationId}/read`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n._id === notificationId ? { ...n, isRead: true } : n
+        )
+      );
+    } catch (err) {
+      console.error("تعذّر تحديث حالة الإشعار", err);
+    }
+  };
 
   if (loading || !user) {
     return (
@@ -83,6 +149,63 @@ const Account: React.FC = () => {
             تسجيل الخروج
           </Button>
         </div>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-bold mb-4">إشعاراتي</h2>
+          {notificationsLoading ? (
+            <p className="text-gray-500">جاري تحميل الإشعارات…</p>
+          ) : notificationsError ? (
+            <p className="text-destructive">{notificationsError}</p>
+          ) : notifications.length === 0 ? (
+            <p className="text-gray-500">لا يوجد إشعارات بعد.</p>
+          ) : (
+            <div className="space-y-4">
+              {notifications.map((notification) => {
+                const createdAt = new Date(notification.createdAt).toLocaleString(
+                  "ar-EG"
+                );
+                const isUnread = !notification.isRead;
+
+                return (
+                  <div
+                    key={notification._id}
+                    className={`rounded-lg border p-4 shadow-sm transition ${
+                      isUnread
+                        ? "bg-blue-50 dark:bg-blue-950/30"
+                        : "bg-white dark:bg-gray-900"
+                    }`}
+                  >
+                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <h3 className="text-lg font-semibold">
+                          {notification.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground">{createdAt}</p>
+                      </div>
+                      {isUnread && (
+                        <Button
+                          variant="outline"
+                          onClick={() => handleMarkAsRead(notification._id)}
+                          className="self-start md:self-auto"
+                        >
+                          تعليم كمقروء
+                        </Button>
+                      )}
+                    </div>
+                    <p className="mt-3 leading-relaxed">
+                      {notification.message}
+                    </p>
+                    {!isUnread && (
+                      <span className="mt-2 inline-block text-xs text-muted-foreground">
+                        تمت قراءته
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
 
         <h2 className="text-2xl font-bold mb-4">طلباتي</h2>
         {orders.length === 0 ? (

--- a/client/ama/src/pages/AdminDashboard.tsx
+++ b/client/ama/src/pages/AdminDashboard.tsx
@@ -1,10 +1,18 @@
 // src/pages/AdminDashboard.tsx
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAuth } from "@/context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
@@ -56,6 +64,20 @@ const getLiteImage = (p: ProductLite) =>
   p.mainImage ||
   "https://placehold.co/300x200/png?text=No+Image";
 
+type AdminNotification = {
+  _id: string;
+  title: string;
+  message: string;
+  target: "all" | "user";
+  createdAt: string;
+  user?: {
+    _id: string;
+    name?: string;
+    email?: string;
+    phone?: string;
+  } | null;
+};
+
 const AdminDashboard: React.FC = () => {
   const { user, loading, token } = useAuth();
   const navigate = useNavigate();
@@ -87,6 +109,25 @@ const AdminDashboard: React.FC = () => {
   const [users, setUsers] = useState<any[]>([]);
   const [userRoleFilter, setUserRoleFilter] = useState("all");
 
+  // ======================= الإشعارات =======================
+  const [notifications, setNotifications] = useState<AdminNotification[]>([]);
+  const [notificationsLoading, setNotificationsLoading] = useState(false);
+  const [notificationForm, setNotificationForm] = useState({
+    title: "",
+    message: "",
+    target: "all" as "all" | "user",
+    userId: "",
+  });
+  const [notificationError, setNotificationError] = useState<string | null>(
+    null
+  );
+  const [notificationSuccess, setNotificationSuccess] = useState<string | null>(
+    null
+  );
+  const [notificationSubmitting, setNotificationSubmitting] = useState(false);
+  const [notificationsLoadError, setNotificationsLoadError] =
+    useState<string | null>(null);
+
   // ======================= الطلبات =======================
   const [orders, setOrders] = useState<any[]>([]);
   const [filter, setFilter] = useState("all");
@@ -108,6 +149,34 @@ const AdminDashboard: React.FC = () => {
     [token]
   );
 
+  const normalizeNotification = useCallback((raw: any): AdminNotification => {
+    const createdAtValue =
+      typeof raw?.createdAt === "string"
+        ? raw.createdAt
+        : raw?.createdAt
+        ? new Date(raw.createdAt).toISOString()
+        : new Date().toISOString();
+
+    let userInfo: AdminNotification["user"] = null;
+    if (raw?.user && typeof raw.user === "object") {
+      userInfo = {
+        _id: String(raw.user._id || ""),
+        name: raw.user.name || undefined,
+        email: raw.user.email || undefined,
+        phone: raw.user.phone || undefined,
+      };
+    }
+
+    return {
+      _id: String(raw?._id || ""),
+      title: String(raw?.title || ""),
+      message: String(raw?.message || ""),
+      target: raw?.target === "user" ? "user" : "all",
+      createdAt: createdAtValue,
+      user: userInfo,
+    };
+  }, []);
+
   // تحقق من صلاحيات الأدمن
   useEffect(() => {
     if (!loading && (!user || user.role !== "admin")) {
@@ -127,6 +196,36 @@ const AdminDashboard: React.FC = () => {
       .then((res) => setUsers(res.data))
       .catch((err) => console.error("❌ Failed to fetch users", err));
   }, [token, apiHeaders]);
+
+  // جلب الإشعارات
+  useEffect(() => {
+    if (!token) return;
+    let active = true;
+    setNotificationsLoading(true);
+    setNotificationsLoadError(null);
+    axios
+      .get(`${import.meta.env.VITE_API_URL}/api/notifications`, {
+        headers: apiHeaders,
+      })
+      .then((res) => {
+        if (!active) return;
+        const list = Array.isArray(res.data) ? res.data : [];
+        setNotifications(list.map((item: any) => normalizeNotification(item)));
+      })
+      .catch((err) => {
+        if (!active) return;
+        console.error("❌ Failed to fetch notifications", err);
+        setNotificationsLoadError("تعذّر جلب الإشعارات حاليًا");
+      })
+      .finally(() => {
+        if (!active) return;
+        setNotificationsLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [token, apiHeaders, normalizeNotification]);
 
   // دالة جلب الطلبات
   const fetchOrders = async () => {
@@ -252,6 +351,75 @@ const AdminDashboard: React.FC = () => {
     } catch (err) {
       console.error("❌ Error deleting user", err);
       alert("فشل في حذف المستخدم");
+    }
+  };
+
+  const handleCreateNotification = async (
+    event: React.FormEvent<HTMLFormElement>
+  ) => {
+    event.preventDefault();
+    if (!token) return;
+
+    setNotificationError(null);
+    setNotificationSuccess(null);
+
+    const trimmedTitle = notificationForm.title.trim();
+    const trimmedMessage = notificationForm.message.trim();
+
+    if (!trimmedTitle) {
+      setNotificationError("يرجى إدخال عنوان الإشعار");
+      return;
+    }
+
+    if (!trimmedMessage) {
+      setNotificationError("يرجى كتابة نص الإشعار");
+      return;
+    }
+
+    if (notificationForm.target === "user" && !notificationForm.userId) {
+      setNotificationError("يرجى اختيار المستخدم المستهدف");
+      return;
+    }
+
+    setNotificationSubmitting(true);
+
+    try {
+      const payload: {
+        title: string;
+        message: string;
+        target: "all" | "user";
+        userId?: string;
+      } = {
+        title: trimmedTitle,
+        message: trimmedMessage,
+        target: notificationForm.target,
+      };
+
+      if (notificationForm.target === "user") {
+        payload.userId = notificationForm.userId;
+      }
+
+      const { data } = await axios.post(
+        `${import.meta.env.VITE_API_URL}/api/notifications`,
+        payload,
+        { headers: apiHeaders }
+      );
+
+      const created = normalizeNotification(data);
+      setNotifications((prev) =>
+        created._id ? [created, ...prev] : prev
+      );
+      setNotificationsLoadError(null);
+      setNotificationForm({ title: "", message: "", target: "all", userId: "" });
+      setNotificationSuccess("تم إرسال الإشعار بنجاح ✅");
+    } catch (err: any) {
+      console.error("❌ Failed to send notification", err);
+      const message =
+        err?.response?.data?.message ||
+        "تعذّر إرسال الإشعار، حاول مرة أخرى.";
+      setNotificationError(message);
+    } finally {
+      setNotificationSubmitting(false);
     }
   };
 
@@ -408,6 +576,7 @@ const AdminDashboard: React.FC = () => {
             <TabsTrigger value="products">المنتجات</TabsTrigger>
             <TabsTrigger value="orders">الطلبات</TabsTrigger>
             <TabsTrigger value="users">المستخدمين</TabsTrigger>
+            <TabsTrigger value="notifications">الإشعارات</TabsTrigger>
             <TabsTrigger value="discounts">خصومات الطلبات</TabsTrigger>
           </TabsList>
 
@@ -794,13 +963,186 @@ const AdminDashboard: React.FC = () => {
                 مستخدم
               </Button>
             </div>
-            {user?._id && (
-              <UserTable
-                users={filteredUsers}
-                onDelete={handleDeleteUser}
-                currentAdminId={user?._id}
-              />
-            )}
+          {user?._id && (
+            <UserTable
+              users={filteredUsers}
+              onDelete={handleDeleteUser}
+              currentAdminId={user?._id}
+            />
+          )}
+        </TabsContent>
+
+          {/* ======================= تبويب الإشعارات ======================= */}
+          <TabsContent value="notifications">
+            <h2 className="text-xl font-semibold mb-4">إدارة الإشعارات</h2>
+
+            <form
+              onSubmit={handleCreateNotification}
+              className="space-y-4 max-w-2xl ml-auto"
+            >
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  عنوان الإشعار
+                </label>
+                <Input
+                  value={notificationForm.title}
+                  onChange={(e) =>
+                    setNotificationForm((prev) => ({
+                      ...prev,
+                      title: e.target.value,
+                    }))
+                  }
+                  placeholder="مثال: عروض جديدة على المنتجات"
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  نص الإشعار
+                </label>
+                <Textarea
+                  value={notificationForm.message}
+                  onChange={(e) =>
+                    setNotificationForm((prev) => ({
+                      ...prev,
+                      message: e.target.value,
+                    }))
+                  }
+                  rows={4}
+                  placeholder="اكتب تفاصيل الإشعار هنا"
+                  required
+                />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="mb-2 block text-sm font-medium">
+                    الفئة المستهدفة
+                  </label>
+                  <Select
+                    value={notificationForm.target}
+                    onValueChange={(value) =>
+                      setNotificationForm((prev) => ({
+                        ...prev,
+                        target: value as "all" | "user",
+                        userId: value === "user" ? prev.userId : "",
+                      }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="اختر الفئة" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">جميع المستخدمين</SelectItem>
+                      <SelectItem value="user">مستخدم محدد</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {notificationForm.target === "user" && (
+                  <div>
+                    <label className="mb-2 block text-sm font-medium">
+                      اختر المستخدم
+                    </label>
+                    <Select
+                      value={notificationForm.userId || undefined}
+                      onValueChange={(value) =>
+                        setNotificationForm((prev) => ({
+                          ...prev,
+                          userId: value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="اختر المستخدم" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {users.length === 0 ? (
+                          <SelectItem value="" disabled>
+                            لا يوجد مستخدمون
+                          </SelectItem>
+                        ) : (
+                          users.map((u: any) => (
+                            <SelectItem key={u._id} value={u._id}>
+                              {u.name || u.email || u.phone || u._id}
+                            </SelectItem>
+                          ))
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </div>
+
+              {notificationError && (
+                <p className="text-destructive text-sm">
+                  {notificationError}
+                </p>
+              )}
+              {notificationSuccess && (
+                <p className="text-green-600 text-sm">
+                  {notificationSuccess}
+                </p>
+              )}
+
+              <Button type="submit" disabled={notificationSubmitting}>
+                {notificationSubmitting ? "جاري الإرسال..." : "إرسال الإشعار"}
+              </Button>
+            </form>
+
+            <div className="mt-8">
+              <h3 className="text-lg font-semibold mb-3">آخر الإشعارات</h3>
+              {notificationsLoading ? (
+                <p className="text-gray-500">جاري التحميل…</p>
+              ) : notificationsLoadError ? (
+                <p className="text-destructive">{notificationsLoadError}</p>
+              ) : notifications.length === 0 ? (
+                <p className="text-gray-500">لا يوجد إشعارات بعد.</p>
+              ) : (
+                <div className="space-y-3">
+                  {notifications.map((notification) => {
+                    const createdAt = new Date(
+                      notification.createdAt
+                    ).toLocaleString("ar-EG");
+                    const targetLabel =
+                      notification.target === "all"
+                        ? "مرسل إلى جميع المستخدمين"
+                        : `مستخدم محدد: ${
+                            notification.user?.name ||
+                            notification.user?.email ||
+                            notification.user?.phone ||
+                            notification.user?._id ||
+                            "-"
+                          }`;
+
+                    return (
+                      <div
+                        key={notification._id}
+                        className="rounded-lg border p-4 bg-white dark:bg-gray-900 shadow-sm"
+                      >
+                        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                          <div>
+                            <h4 className="font-semibold text-base">
+                              {notification.title}
+                            </h4>
+                            <p className="text-xs text-muted-foreground">
+                              {createdAt}
+                            </p>
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            {targetLabel}
+                          </span>
+                        </div>
+                        <p className="mt-3 text-sm leading-relaxed">
+                          {notification.message}
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           </TabsContent>
 
           {/* ======================= تبويب خصومات الطلبات ======================= */}

--- a/server/index.js
+++ b/server/index.js
@@ -338,6 +338,7 @@ app.use("/api/variants", require("./routes/variants"));
 app.use("/api/products", require("./routes/products"));
 app.use("/api/orders", require("./routes/orders"));
 app.use("/api/users", require("./routes/user"));
+app.use("/api/notifications", require("./routes/notifications"));
 app.use("/api/discount-rules", require("./routes/discountRules"));
 app.use("/api/discounts", require("./routes/discounts"));
 app.use("/api/home-collections", require("./routes/homeCollections"));

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+
+const notificationSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    message: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    target: {
+      type: String,
+      enum: ["all", "user"],
+      default: "all",
+    },
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: function () {
+        return this.target === "user";
+      },
+    },
+    readBy: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model("Notification", notificationSchema);

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,0 +1,161 @@
+const express = require("express");
+const router = express.Router();
+
+const Notification = require("../models/Notification");
+const User = require("../models/User");
+const { verifyToken, isAdmin } = require("../middleware/authMiddleware");
+
+// ✅ إنشاء إشعار جديد (أدمن فقط)
+router.post("/", verifyToken, isAdmin, async (req, res) => {
+  const { title, message, target = "all", userId } = req.body || {};
+
+  const trimmedTitle = String(title || "").trim();
+  const trimmedMessage = String(message || "").trim();
+  const normalizedTarget = target === "user" ? "user" : "all";
+
+  if (!trimmedTitle) {
+    return res.status(400).json({ message: "العنوان مطلوب" });
+  }
+
+  if (!trimmedMessage) {
+    return res.status(400).json({ message: "نص الإشعار مطلوب" });
+  }
+
+  try {
+    let user = null;
+    if (normalizedTarget === "user") {
+      if (!userId) {
+        return res
+          .status(400)
+          .json({ message: "يجب تحديد المستخدم عند اختيار إشعار مخصص" });
+      }
+      user = await User.findById(userId).select("_id name email phone");
+      if (!user) {
+        return res
+          .status(404)
+          .json({ message: "المستخدم المطلوب غير موجود" });
+      }
+    }
+
+    const notification = await Notification.create({
+      title: trimmedTitle,
+      message: trimmedMessage,
+      target: normalizedTarget,
+      user: normalizedTarget === "user" ? user._id : undefined,
+    });
+
+    const populated = await notification.populate("user", "name email phone");
+
+    return res.status(201).json(populated);
+  } catch (err) {
+    console.error("Failed to create notification", err);
+    return res
+      .status(500)
+      .json({ message: "تعذّر إنشاء الإشعار، حاول مرة أخرى لاحقًا" });
+  }
+});
+
+// ✅ جلب كل الإشعارات (أدمن فقط)
+router.get("/", verifyToken, isAdmin, async (_req, res) => {
+  try {
+    const notifications = await Notification.find()
+      .sort({ createdAt: -1 })
+      .populate("user", "name email phone")
+      .lean();
+
+    return res.json(Array.isArray(notifications) ? notifications : []);
+  } catch (err) {
+    console.error("Failed to fetch notifications", err);
+    return res
+      .status(500)
+      .json({ message: "تعذّر جلب الإشعارات، حاول مرة أخرى لاحقًا" });
+  }
+});
+
+// ✅ جلب إشعارات المستخدم الحالي
+router.get("/my", verifyToken, async (req, res) => {
+  const userId = req.user?.id;
+
+  if (!userId) {
+    return res.status(401).json({ message: "يرجى تسجيل الدخول أولًا" });
+  }
+
+  try {
+    const notifications = await Notification.find({
+      $or: [
+        { target: "all" },
+        { target: "user", user: userId },
+      ],
+    })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const mapped = notifications.map((n) => ({
+      _id: n._id,
+      title: n.title,
+      message: n.message,
+      target: n.target,
+      createdAt: n.createdAt,
+      isRead: Array.isArray(n.readBy)
+        ? n.readBy.some((reader) => String(reader) === String(userId))
+        : false,
+    }));
+
+    return res.json(mapped);
+  } catch (err) {
+    console.error("Failed to fetch user notifications", err);
+    return res
+      .status(500)
+      .json({ message: "تعذّر جلب الإشعارات، حاول مرة أخرى لاحقًا" });
+  }
+});
+
+// ✅ تعليم الإشعار كمقروء للمستخدم الحالي
+router.patch("/:id/read", verifyToken, async (req, res) => {
+  const userId = req.user?.id;
+  const { id } = req.params;
+
+  if (!userId) {
+    return res.status(401).json({ message: "يرجى تسجيل الدخول أولًا" });
+  }
+
+  try {
+    const notification = await Notification.findOneAndUpdate(
+      {
+        _id: id,
+        $or: [
+          { target: "all" },
+          { target: "user", user: userId },
+        ],
+      },
+      { $addToSet: { readBy: userId } },
+      { new: true }
+    )
+      .select("_id title message target createdAt readBy")
+      .lean();
+
+    if (!notification) {
+      return res.status(404).json({ message: "الإشعار غير موجود" });
+    }
+
+    const isRead = Array.isArray(notification.readBy)
+      ? notification.readBy.some((reader) => String(reader) === String(userId))
+      : false;
+
+    return res.json({
+      _id: notification._id,
+      title: notification.title,
+      message: notification.message,
+      target: notification.target,
+      createdAt: notification.createdAt,
+      isRead,
+    });
+  } catch (err) {
+    console.error("Failed to mark notification as read", err);
+    return res
+      .status(500)
+      .json({ message: "تعذّر تحديث الإشعار، حاول مرة أخرى لاحقًا" });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add a Notification model plus secured routes so admins can create updates and customers can read or mark them
- expose a notifications tab inside the admin dashboard to send messages and review recent items
- surface account page alerts with unread highlighting and a mark-as-read action for shoppers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7570be1288330952884354dcc7119