### PR TITLE
Add favorites functionality and navbar notifications

### DIFF
--- a/client/ama/src/App.tsx
+++ b/client/ama/src/App.tsx
@@ -10,6 +10,7 @@ import Register from "./pages/Register";
 import ProductDetails from "@/pages/ProductDetails";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Terms from "./pages/Terms";
+import Favorites from "./pages/Favorites";
 import AdminDashboard from "./pages/AdminDashboard";
 import UserOrderDetails from "./pages/UserOrderDetails";
 // import OfferDialog from "./components/common/OfferDialog";
@@ -36,6 +37,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/products" element={<Products />} />
+        <Route path="/favorites" element={<Favorites />} />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/cart" element={<Cart />} />

--- a/client/ama/src/components/Navbar.tsx
+++ b/client/ama/src/components/Navbar.tsx
@@ -1,28 +1,58 @@
-import React, { useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import axios from "axios";
 import { Link, useNavigate } from "react-router-dom";
+import clsx from "clsx";
 import CartButton from "@/components/CartButton";
 import { Button } from "@/components/ui/button";
-import { Menu } from "lucide-react";
+import { Bell, Menu } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import ThemeToggle from "@/components/ThemeToggle";
 import LanguageToggle from "@/components/LanguageToggle";
 import { useTranslation } from "@/i18n";
 // import OfferBanner from "./common/OfferBanner";
 
+type NotificationItem = {
+  _id: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  isRead?: boolean;
+};
+
+const MAX_NAV_NOTIFICATIONS = 5;
+
 const Navbar: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { user, logout } = useAuth();
+  const { user, logout, token } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
   // const [showBanner, setShowBanner] = useState(true);
   // const bannerinfo = useRef(
   //   "خصم اجمالي على كل الفواتير الاعلى من ١٠٠٠ شيقل بقيمه ٥٪"
   // );
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [notificationsLoading, setNotificationsLoading] = useState(false);
+  const [notificationsError, setNotificationsError] = useState<string | null>(
+    null
+  );
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [unreadIds, setUnreadIds] = useState<string[]>([]);
+  const mobileNotificationsRef = useRef<HTMLDivElement | null>(null);
+  const desktopNotificationsRef = useRef<HTMLDivElement | null>(null);
+
   const showThemeToggle = !user || user.role !== "admin";
   const baseLinks = useMemo(
     () => [
       { key: "home", path: "/" },
       { key: "products", path: "/products" },
+      { key: "favorites", path: "/favorites" },
       { key: "about", path: "/about" },
       { key: "contact", path: "/contact" },
       { key: "account", path: "/account" },
@@ -40,6 +70,249 @@ const Navbar: React.FC = () => {
       name: t(`navbar.links.${link.key}` as const),
     }));
   }, [baseLinks, t, user]);
+
+  const canShowNotifications = Boolean(user && token);
+
+  const formatNotificationDate = useCallback((value: string) => {
+    if (!value) return "";
+    try {
+      return new Date(value).toLocaleString();
+    } catch {
+      return value;
+    }
+  }, []);
+
+  const fetchNotifications = useCallback(async () => {
+    if (!canShowNotifications) {
+      setNotifications([]);
+      setUnreadCount(0);
+      setUnreadIds([]);
+      setNotificationsError(null);
+      setNotificationsLoading(false);
+      return [] as string[];
+    }
+
+    setNotificationsLoading(true);
+    setNotificationsError(null);
+    try {
+      const response = await axios.get(
+        `${import.meta.env.VITE_API_URL}/api/notifications/my`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const list = Array.isArray(response.data) ? response.data : [];
+      const sorted = [...list].sort((a, b) => {
+        const aTime = new Date(a?.createdAt ?? 0).getTime();
+        const bTime = new Date(b?.createdAt ?? 0).getTime();
+        return bTime - aTime;
+      });
+
+      const limited = sorted.slice(0, MAX_NAV_NOTIFICATIONS);
+      setNotifications(limited);
+
+      const unreadItems = list.filter((item: NotificationItem) => !item.isRead);
+      const unreadIdsList = unreadItems.map((item) => item._id);
+      setUnreadIds(unreadIdsList);
+      setUnreadCount(unreadIdsList.length);
+      return unreadIdsList;
+    } catch (error) {
+      console.error("❌ Failed to load notifications", error);
+      setNotificationsError(t("navbar.notifications.error"));
+      return [];
+    } finally {
+      setNotificationsLoading(false);
+    }
+  }, [canShowNotifications, t, token]);
+
+  const markAllAsRead = useCallback(
+    async (ids?: string[]) => {
+      if (!canShowNotifications) return;
+      const targetIds = (ids ?? unreadIds).filter(Boolean);
+      if (targetIds.length === 0) return;
+
+      setNotifications((prev) =>
+        prev.map((notification) =>
+          targetIds.includes(notification._id)
+            ? { ...notification, isRead: true }
+            : notification
+        )
+      );
+      setUnreadIds((prev) =>
+        prev.filter((identifier) => !targetIds.includes(identifier))
+      );
+      setUnreadCount((prev) =>
+        prev - targetIds.length > 0 ? prev - targetIds.length : 0
+      );
+
+      try {
+        await Promise.all(
+          targetIds.map((id) =>
+            axios.patch(
+              `${import.meta.env.VITE_API_URL}/api/notifications/${id}/read`,
+              {},
+              {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              }
+            )
+          )
+        );
+      } catch (error) {
+        console.error("❌ Failed to mark notifications as read", error);
+      }
+    },
+    [canShowNotifications, token, unreadIds]
+  );
+
+  useEffect(() => {
+    if (!canShowNotifications) {
+      setNotificationsOpen(false);
+      return;
+    }
+    void fetchNotifications();
+  }, [canShowNotifications, fetchNotifications]);
+
+  useEffect(() => {
+    if (!notificationsOpen) return;
+    let cancelled = false;
+    (async () => {
+      const ids = await fetchNotifications();
+      if (cancelled) return;
+      if (ids.length > 0) {
+        await markAllAsRead(ids);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [notificationsOpen, fetchNotifications, markAllAsRead]);
+
+  useEffect(() => {
+    if (!notificationsOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        (mobileNotificationsRef.current &&
+          mobileNotificationsRef.current.contains(target)) ||
+        (desktopNotificationsRef.current &&
+          desktopNotificationsRef.current.contains(target))
+      ) {
+        return;
+      }
+      setNotificationsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setNotificationsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [notificationsOpen]);
+
+  const renderNotificationsMenu = (
+    ref: React.RefObject<HTMLDivElement | null>,
+    alignment: "left" | "right" = "right"
+  ) => (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => {
+          if (!canShowNotifications) return;
+          setNotificationsOpen((prev) => !prev);
+        }}
+        className={clsx(
+          "relative inline-flex h-10 w-10 items-center justify-center rounded-full border transition",
+          canShowNotifications
+            ? "bg-white text-gray-700 hover:bg-gray-100 dark:bg-slate-900 dark:text-slate-100"
+            : "bg-gray-200 text-gray-400 cursor-not-allowed"
+        )}
+        aria-haspopup="true"
+        aria-expanded={notificationsOpen}
+        aria-label={t("navbar.notifications.title")}
+        disabled={!canShowNotifications}
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-[1.25rem] rounded-full bg-red-600 px-1 text-[0.65rem] font-semibold leading-none text-white">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {notificationsOpen && (
+        <div
+          className={clsx(
+            "absolute z-40 mt-2 w-80 max-w-[90vw] rounded-lg border border-gray-100 bg-white shadow-xl dark:border-slate-800 dark:bg-slate-950",
+            alignment === "right" ? "right-0" : "left-0"
+          )}
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-gray-100 px-4 py-3 text-right dark:border-slate-800">
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">
+              {t("navbar.notifications.title")}
+            </span>
+            <span className="text-xs text-gray-500 dark:text-slate-400">
+              {t("navbar.notifications.unread", { count: unreadCount })}
+            </span>
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {notificationsLoading ? (
+              <p className="px-4 py-3 text-sm text-muted-foreground">
+                {t("navbar.notifications.loading")}
+              </p>
+            ) : notificationsError ? (
+              <p className="px-4 py-3 text-sm text-destructive">
+                {notificationsError}
+              </p>
+            ) : notifications.length === 0 ? (
+              <p className="px-4 py-3 text-sm text-muted-foreground">
+                {t("navbar.notifications.empty")}
+              </p>
+            ) : (
+              notifications.map((notification) => (
+                <div
+                  key={notification._id}
+                  className="border-b border-gray-100 px-4 py-3 text-right last:border-0 dark:border-slate-800"
+                >
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                    {notification.title}
+                  </p>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-slate-300">
+                    {notification.message}
+                  </p>
+                  <span className="mt-2 block text-[0.7rem] text-gray-400 dark:text-slate-400">
+                    {formatNotificationDate(notification.createdAt)}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="border-t border-gray-100 bg-gray-50 px-4 py-2 text-right text-sm dark:border-slate-800 dark:bg-slate-900/60">
+            <Link
+              to="/account"
+              className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+              onClick={() => setNotificationsOpen(false)}
+            >
+              {t("navbar.notifications.viewAll")}
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <header className="sticky top-0 inset-x-0 z-50 border-b bg-white/90 dark:bg-slate-950/90 backdrop-blur shadow-sm mb-6">
@@ -63,6 +336,7 @@ const Navbar: React.FC = () => {
 
         {/* زر القائمة للجوال */}
         <div className="flex items-center gap-2 lg:hidden">
+          {renderNotificationsMenu(mobileNotificationsRef)}
           <CartButton />
           <Button
             variant="ghost"
@@ -110,6 +384,7 @@ const Navbar: React.FC = () => {
             </div>
           )}
 
+          {renderNotificationsMenu(desktopNotificationsRef)}
           <CartButton />
         </div>
       </nav>

--- a/client/ama/src/components/ProductCard.tsx
+++ b/client/ama/src/components/ProductCard.tsx
@@ -10,12 +10,21 @@ import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import clsx from "clsx";
 import { useCart } from "@/context/CartContext";
+import { useFavorites, type FavoriteProduct } from "@/context/FavoritesContext";
 import { Button } from "@/components/ui/button";
 import { getLocalizedText, type LocalizedText } from "@/lib/localized";
 import { getColorLabel } from "@/lib/colors";
 import { useLanguage } from "@/context/LanguageContext";
 import { useTranslation } from "@/i18n";
-import { Loader2, Check, Plus, X, ChevronUp, ChevronDown } from "lucide-react";
+import {
+  Loader2,
+  Check,
+  Plus,
+  X,
+  ChevronUp,
+  ChevronDown,
+  Heart,
+} from "lucide-react";
 import { dispatchCartHighlight } from "@/lib/cartHighlight";
 
 interface Props {
@@ -83,6 +92,19 @@ const ProductCard: React.FC<Props> = ({ product }) => {
     () => getLocalizedText(product.description, locale) || "",
     [product.description, locale]
   );
+
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const favoritePayload = useMemo<FavoriteProduct>(
+    () => ({
+      ...product,
+      price: product.price ?? 0,
+    }),
+    [product]
+  );
+  const isFavoriteProduct = isFavorite(product._id);
+  const handleToggleFavorite = useCallback(() => {
+    toggleFavorite(favoritePayload);
+  }, [favoritePayload, toggleFavorite]);
 
   // حالات مشتركة
   const [currentImage, setCurrentImage] = useState(0);
@@ -478,14 +500,40 @@ const ProductCard: React.FC<Props> = ({ product }) => {
             </p>
           )}
         </div>
-        <button
-          type="button"
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-gray-100 text-gray-700 transition hover:bg-gray-200"
-          onClick={() => setIsDetailsOpen(false)}
-          aria-label={t("productCard.cancel")}
-        >
-          <X className="h-4 w-4" aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className={clsx(
+              "inline-flex h-9 w-9 items-center justify-center rounded-full border transition",
+              isFavoriteProduct
+                ? "bg-red-600 text-white border-red-500 hover:bg-red-500"
+                : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100"
+            )}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleToggleFavorite();
+            }}
+            aria-label={
+              isFavoriteProduct
+                ? t("productCard.removeFavorite")
+                : t("productCard.addFavorite")
+            }
+          >
+            <Heart
+              className="h-4 w-4"
+              fill={isFavoriteProduct ? "currentColor" : "none"}
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-gray-100 text-gray-700 transition hover:bg-gray-200"
+            onClick={() => setIsDetailsOpen(false)}
+            aria-label={t("productCard.cancel")}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
       <div className="flex items-center justify-between gap-3">
@@ -659,6 +707,31 @@ const ProductCard: React.FC<Props> = ({ product }) => {
             </>
           )}
 
+          <button
+            type="button"
+            className={clsx(
+              "absolute top-2 left-2 z-30 inline-flex h-9 w-9 items-center justify-center rounded-full border shadow-sm transition",
+              isFavoriteProduct
+                ? "bg-red-600 text-white border-red-500 hover:bg-red-500"
+                : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100"
+            )}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleToggleFavorite();
+            }}
+            aria-label={
+              isFavoriteProduct
+                ? t("productCard.removeFavorite")
+                : t("productCard.addFavorite")
+            }
+          >
+            <Heart
+              className="h-4 w-4"
+              fill={isFavoriteProduct ? "currentColor" : "none"}
+              aria-hidden="true"
+            />
+          </button>
+
           {discountPercent !== null && (
             <span className="absolute top-2 right-2 bg-red-600 text-white text-xs font-bold px-2 py-1 rounded z-20">
               -{discountPercent}%
@@ -735,9 +808,9 @@ const ProductCard: React.FC<Props> = ({ product }) => {
         >
           <div
             className="relative w-full aspect-[4/5] mb-2 overflow-hidden rounded bg-white cursor-pointer"
-          onClick={() => navigate(`/products/${product._id}`)}
-          role="button"
-          tabIndex={0}
+            onClick={() => navigate(`/products/${product._id}`)}
+            role="button"
+            tabIndex={0}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               event.preventDefault();
@@ -816,6 +889,31 @@ const ProductCard: React.FC<Props> = ({ product }) => {
               </button>
             </>
           )}
+
+          <button
+            type="button"
+            className={clsx(
+              "absolute top-2 left-2 z-30 inline-flex h-9 w-9 items-center justify-center rounded-full border shadow-sm transition",
+              isFavoriteProduct
+                ? "bg-red-600 text-white border-red-500 hover:bg-red-500"
+                : "bg-white text-gray-700 border-gray-200 hover:bg-gray-100"
+            )}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleToggleFavorite();
+            }}
+            aria-label={
+              isFavoriteProduct
+                ? t("productCard.removeFavorite")
+                : t("productCard.addFavorite")
+            }
+          >
+            <Heart
+              className="h-4 w-4"
+              fill={isFavoriteProduct ? "currentColor" : "none"}
+              aria-hidden="true"
+            />
+          </button>
 
           {discountPercent !== null && (
             <span className="absolute top-2 right-2 bg-red-600 text-white text-xs font-bold px-2 py-1 rounded z-20">

--- a/client/ama/src/context/FavoritesContext.tsx
+++ b/client/ama/src/context/FavoritesContext.tsx
@@ -1,0 +1,155 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import type { LocalizedText } from "@/lib/localized";
+
+export type FavoriteProduct = {
+  _id: string;
+  name: LocalizedText;
+  description: LocalizedText;
+  price: number;
+  images?: string[];
+  subCategory?: string;
+};
+
+type FavoritesContextType = {
+  favorites: FavoriteProduct[];
+  addFavorite: (product: FavoriteProduct) => void;
+  removeFavorite: (productId: string) => void;
+  toggleFavorite: (product: FavoriteProduct) => void;
+  isFavorite: (productId: string) => boolean;
+};
+
+const FavoritesContext = createContext<FavoritesContextType | null>(null);
+
+const normalizeFavorite = (
+  item: Partial<FavoriteProduct>
+): FavoriteProduct | null => {
+  if (!item || !item._id) return null;
+  return {
+    _id: item._id,
+    name: (item.name ?? "") as LocalizedText,
+    description: (item.description ?? "") as LocalizedText,
+    price: typeof item.price === "number" ? item.price : 0,
+    images: Array.isArray(item.images) ? item.images : undefined,
+    subCategory: item.subCategory,
+  };
+};
+
+const STORAGE_KEY = "dikori_favorites_v1";
+
+export const FavoritesProvider = ({ children }: { children: ReactNode }) => {
+  const [favorites, setFavorites] = useState<FavoriteProduct[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw) as Partial<FavoriteProduct>[];
+      if (!Array.isArray(parsed)) return [];
+      const normalized = parsed
+        .map((item) => normalizeFavorite(item))
+        .filter((item): item is FavoriteProduct => item !== null);
+      const unique = new Map(normalized.map((item) => [item._id, item]));
+      return Array.from(unique.values());
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+    } catch {
+      // Ignore storage errors (quota, private mode, ...)
+    }
+  }, [favorites]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      if (!event.newValue) {
+        setFavorites([]);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(event.newValue) as Partial<FavoriteProduct>[];
+        if (Array.isArray(parsed)) {
+          const normalized = parsed
+            .map((item) => normalizeFavorite(item))
+            .filter((item): item is FavoriteProduct => item !== null);
+          setFavorites(normalized);
+        }
+      } catch {
+        // ignore malformed payloads
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  const addFavorite = useCallback((product: FavoriteProduct) => {
+    setFavorites((prev) => {
+      if (prev.some((item) => item._id === product._id)) return prev;
+      const entry: FavoriteProduct = {
+        ...product,
+        price: product.price ?? 0,
+      };
+      return [...prev, entry];
+    });
+  }, []);
+
+  const removeFavorite = useCallback((productId: string) => {
+    setFavorites((prev) => prev.filter((item) => item._id !== productId));
+  }, []);
+
+  const toggleFavorite = useCallback((product: FavoriteProduct) => {
+    setFavorites((prev) => {
+      const exists = prev.some((item) => item._id === product._id);
+      if (exists) {
+        return prev.filter((item) => item._id !== product._id);
+      }
+      const entry: FavoriteProduct = {
+        ...product,
+        price: product.price ?? 0,
+      };
+      return [...prev, entry];
+    });
+  }, []);
+
+  const isFavorite = useCallback(
+    (productId: string) => favorites.some((item) => item._id === productId),
+    [favorites]
+  );
+
+  const value = useMemo(
+    () => ({
+      favorites,
+      addFavorite,
+      removeFavorite,
+      toggleFavorite,
+      isFavorite,
+    }),
+    [favorites, addFavorite, removeFavorite, toggleFavorite, isFavorite]
+  );
+
+  return (
+    <FavoritesContext.Provider value={value}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};
+
+export const useFavorites = () => {
+  const ctx = useContext(FavoritesContext);
+  if (!ctx) {
+    throw new Error("useFavorites must be used within a FavoritesProvider");
+  }
+  return ctx;
+};

--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -4,6 +4,7 @@
     "links": {
       "home": "الرئيسية",
       "products": "المنتجات",
+      "favorites": "المفضلة",
       "about": "من نحن",
       "contact": "تواصل معنا",
       "account": "حسابي",
@@ -14,6 +15,14 @@
       "register": "إنشاء حساب",
       "greeting": "أهلاً، {{name}}",
       "logout": "تسجيل الخروج"
+    },
+    "notifications": {
+      "title": "الإشعارات",
+      "loading": "جاري تحميل الإشعارات…",
+      "empty": "لا توجد إشعارات جديدة.",
+      "error": "تعذّر تحميل الإشعارات.",
+      "viewAll": "عرض كل الإشعارات",
+      "unread": "غير المقروءة: {{count}}"
     }
   },
   "footer": {
@@ -189,6 +198,8 @@
   },
   "productDetails": {
     "loading": "جاري تحميل تفاصيل المنتج...",
+    "addToFavorites": "أضف إلى المفضلة",
+    "removeFavorite": "إزالة من المفضلة",
     "measureLabel": "المقاس",
     "colorLabel": "اللون",
     "colorUnavailable": "— غير متاح لهذا المقاس",
@@ -217,6 +228,12 @@
       "outOfStock": "غير متوفر"
     }
   },
+  "favoritesPage": {
+    "title": "مفضلتي",
+    "empty": "لم تقم بإضافة أي منتجات إلى المفضلة بعد.",
+    "browse": "تصفّح المنتجات",
+    "count": "{{count}} منتج في المفضلة"
+  },
   "productCard": {
     "previousImage": "الصورة السابقة",
     "nextImage": "الصورة التالية",
@@ -234,7 +251,9 @@
     "cancel": "إلغاء",
     "quantityLabel": "الكمية",
     "inStock": "المتوفر: {{count}}",
-    "outOfStock": "غير متوفر حالياً"
+    "outOfStock": "غير متوفر حالياً",
+    "addFavorite": "إضافة إلى المفضلة",
+    "removeFavorite": "إزالة من المفضلة"
   },
   "common": {
     "all": "الكل",

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -9,6 +9,7 @@
     "links": {
       "home": "דף הבית",
       "products": "מוצרים",
+      "favorites": "מועדפים",
       "about": "אודות",
       "contact": "צור קשר",
       "account": "החשבון שלי",
@@ -19,6 +20,14 @@
       "register": "יצירת חשבון",
       "greeting": "שלום, {{name}}",
       "logout": "התנתקות"
+    },
+    "notifications": {
+      "title": "התראות",
+      "loading": "טוען התראות…",
+      "empty": "אין התראות חדשות.",
+      "error": "אירעה שגיאה בטעינת ההתראות.",
+      "viewAll": "צפה בכל ההתראות",
+      "unread": "לא נקראו: {{count}}"
     }
   },
   "footer": {
@@ -194,6 +203,8 @@
   },
   "productDetails": {
     "loading": "טוען פרטי מוצר...",
+    "addToFavorites": "הוסף למועדפים",
+    "removeFavorite": "הסר מהמועדפים",
     "measureLabel": "מידה",
     "colorLabel": "צבע",
     "colorUnavailable": "— לא זמין במידה זו",
@@ -222,6 +233,12 @@
       "outOfStock": "אזל מהמלאי"
     }
   },
+  "favoritesPage": {
+    "title": "המועדפים שלי",
+    "empty": "לא הוספת עדיין מוצרים לרשימת המועדפים.",
+    "browse": "לעיין במוצרים",
+    "count": "{{count}} מוצרים במועדפים"
+  },
   "productCard": {
     "previousImage": "התמונה הקודמת",
     "nextImage": "התמונה הבאה",
@@ -239,7 +256,9 @@
     "cancel": "ביטול",
     "quantityLabel": "כמות",
     "inStock": "זמין במלאי: {{count}}",
-    "outOfStock": "אזל מהמלאי"
+    "outOfStock": "אזל מהמלאי",
+    "addFavorite": "הוסף למועדפים",
+    "removeFavorite": "הסר מהמועדפים"
   },
   "common": {
     "all": "הכול",

--- a/client/ama/src/main.tsx
+++ b/client/ama/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { CartProvider } from "@/context/CartContext";
+import { FavoritesProvider } from "@/context/FavoritesContext";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { I18nextProvider } from "react-i18next";
 
@@ -14,12 +15,14 @@ createRoot(document.getElementById("root")!).render(
   <I18nextProvider i18n={i18n}>
     <LanguageProvider>
       <AuthProvider>
-        <CartProvider>
-          <BrowserRouter>
-            <SpeedInsights />
-            <App />
-          </BrowserRouter>
-        </CartProvider>
+        <FavoritesProvider>
+          <CartProvider>
+            <BrowserRouter>
+              <SpeedInsights />
+              <App />
+            </BrowserRouter>
+          </CartProvider>
+        </FavoritesProvider>
       </AuthProvider>
     </LanguageProvider>
   </I18nextProvider>

--- a/client/ama/src/pages/Favorites.tsx
+++ b/client/ama/src/pages/Favorites.tsx
@@ -1,0 +1,49 @@
+import { Link } from "react-router-dom";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import ProductCard from "@/components/ProductCard";
+import { Button } from "@/components/ui/button";
+import { useFavorites } from "@/context/FavoritesContext";
+import { useTranslation } from "@/i18n";
+
+const Favorites: React.FC = () => {
+  const { favorites } = useFavorites();
+  const { t } = useTranslation();
+  const hasFavorites = favorites.length > 0;
+
+  return (
+    <>
+      <Navbar />
+      <main className="container mx-auto p-6 text-right min-h-[60vh]">
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <h1 className="text-3xl font-bold">{t("favoritesPage.title")}</h1>
+          {hasFavorites && (
+            <span className="text-sm text-muted-foreground">
+              {t("favoritesPage.count", { count: favorites.length })}
+            </span>
+          )}
+        </div>
+
+        {hasFavorites ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {favorites.map((product) => (
+              <ProductCard key={product._id} product={product} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+            <p className="text-muted-foreground text-lg">
+              {t("favoritesPage.empty")}
+            </p>
+            <Button asChild>
+              <Link to="/products">{t("favoritesPage.browse")}</Link>
+            </Button>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+};
+
+export default Favorites;


### PR DESCRIPTION
## Summary
- add a Favorites context/provider with a dedicated page for reviewing saved products
- expose add/remove favorite actions on product cards and the product details view while wiring the route and translations
- surface a notification dropdown in the navbar with unread badges and localization updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f77390aba88330a7c10db5c44c4ab2