### PR TITLE
Fix navbar notifications refetch loop

### DIFF
--- a/client/ama/src/components/Navbar.tsx
+++ b/client/ama/src/components/Navbar.tsx
@@ -44,6 +44,7 @@ const Navbar: React.FC = () => {
   );
   const [unreadCount, setUnreadCount] = useState(0);
   const [unreadIds, setUnreadIds] = useState<string[]>([]);
+  const unreadIdsRef = useRef<string[]>([]);
   const mobileNotificationsRef = useRef<HTMLDivElement | null>(null);
   const desktopNotificationsRef = useRef<HTMLDivElement | null>(null);
 
@@ -128,10 +129,14 @@ const Navbar: React.FC = () => {
     }
   }, [canShowNotifications, t, token]);
 
+  useEffect(() => {
+    unreadIdsRef.current = unreadIds;
+  }, [unreadIds]);
+
   const markAllAsRead = useCallback(
     async (ids?: string[]) => {
       if (!canShowNotifications) return;
-      const targetIds = (ids ?? unreadIds).filter(Boolean);
+      const targetIds = (ids ?? unreadIdsRef.current).filter(Boolean);
       if (targetIds.length === 0) return;
 
       setNotifications((prev) =>
@@ -166,7 +171,7 @@ const Navbar: React.FC = () => {
         console.error("❌ Failed to mark notifications as read", error);
       }
     },
-    [canShowNotifications, token, unreadIds]
+    [canShowNotifications, token]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep a stable reference to unread notification ids when marking them as read
- prevent the navbar notification dropdown from refetching in a tight loop

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f77a527bc48330a48df7cb405f8eb9