### PR TITLE
Add countdown timer and original price for discounted variants

### DIFF
--- a/client/ama/src/lib/time.ts
+++ b/client/ama/src/lib/time.ts
@@ -1,0 +1,48 @@
+export type TimeUnit = "days" | "hours" | "minutes" | "seconds";
+
+export type TimePart = { unit: TimeUnit; value: number };
+
+export type FormattedTimeLeft = { expired: boolean; parts: TimePart[] };
+
+export const clamp = (n: number, min = 0, max = 100) =>
+  Math.max(min, Math.min(max, n));
+
+export const formatTimeLeft = (ms: number): FormattedTimeLeft => {
+  if (ms <= 0) return { expired: true, parts: [] };
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) {
+    return {
+      expired: false,
+      parts: [
+        { unit: "days", value: days },
+        { unit: "hours", value: hours },
+        { unit: "minutes", value: minutes },
+      ],
+    };
+  }
+
+  if (hours > 0) {
+    return {
+      expired: false,
+      parts: [
+        { unit: "hours", value: hours },
+        { unit: "minutes", value: minutes },
+        { unit: "seconds", value: seconds },
+      ],
+    };
+  }
+
+  return {
+    expired: false,
+    parts: [
+      { unit: "minutes", value: minutes },
+      { unit: "seconds", value: seconds },
+    ],
+  };
+};

--- a/client/ama/src/locales/ar/common.json
+++ b/client/ama/src/locales/ar/common.json
@@ -245,8 +245,18 @@
     "sizesLabel": "المقاسات",
     "colorLabel": "اللون",
     "colorsLabel": "الألوان",
-    "discountTimerTitle": "مدّة الخصم",
-    "discountTimer": "ينتهي قريبًا",
+    "discount": {
+      "progressTitle": "مدّة الخصم",
+      "progressAria": "مدّة الخصم المتبقية",
+      "endsIn": "ينتهي خلال:",
+      "ended": "انتهى الخصم",
+      "parts": {
+        "days": "{{value}}ي",
+        "hours": "{{value}}س",
+        "minutes": "{{value}}د",
+        "seconds": "{{value}}ث"
+      }
+    },
     "dialogDescription": "اختر اللون والمقاس قبل إضافة المنتج إلى السلة.",
     "cancel": "إلغاء",
     "quantityLabel": "الكمية",

--- a/client/ama/src/locales/he/common.json
+++ b/client/ama/src/locales/he/common.json
@@ -250,8 +250,18 @@
     "sizesLabel": "מידות",
     "colorLabel": "צבע",
     "colorsLabel": "צבעים",
-    "discountTimerTitle": "משך ההנחה",
-    "discountTimer": "מסתיים בקרוב",
+    "discount": {
+      "progressTitle": "משך ההנחה",
+      "progressAria": "הזמן שנותר להנחה",
+      "endsIn": "נגמר בעוד:",
+      "ended": "ההנחה הסתיימה",
+      "parts": {
+        "days": "{{value}} ימים",
+        "hours": "{{value}} שעות",
+        "minutes": "{{value}} דקות",
+        "seconds": "{{value}} שניות"
+      }
+    },
     "dialogDescription": "בחרו צבע ומידה לפני הוספת המוצר לעגלה.",
     "cancel": "ביטול",
     "quantityLabel": "כמות",

--- a/client/ama/src/pages/ProductDetails.tsx
+++ b/client/ama/src/pages/ProductDetails.tsx
@@ -17,6 +17,7 @@ import {
   compareVariantsByDiscount,
   resolveVariantPricing,
 } from "@/lib/variantPricing";
+import { clamp, formatTimeLeft } from "@/lib/time";
 
 type Variant = {
   _id: string;
@@ -41,53 +42,6 @@ type Variant = {
   finalAmount?: number;
   isDiscountActive?: boolean;
   displayCompareAt?: number | null;
-};
-
-const clamp = (n: number, min = 0, max = 100) =>
-  Math.max(min, Math.min(max, n));
-
-type TimeUnit = "days" | "hours" | "minutes" | "seconds";
-
-const formatTimeLeft = (
-  ms: number
-): { expired: boolean; parts: { unit: TimeUnit; value: number }[] } => {
-  if (ms <= 0) return { expired: true, parts: [] };
-
-  const totalSeconds = Math.floor(ms / 1000);
-  const days = Math.floor(totalSeconds / 86400);
-  const hours = Math.floor((totalSeconds % 86400) / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-
-  if (days > 0) {
-    return {
-      expired: false,
-      parts: [
-        { unit: "days", value: days },
-        { unit: "hours", value: hours },
-        { unit: "minutes", value: minutes },
-      ],
-    };
-  }
-
-  if (hours > 0) {
-    return {
-      expired: false,
-      parts: [
-        { unit: "hours", value: hours },
-        { unit: "minutes", value: minutes },
-        { unit: "seconds", value: seconds },
-      ],
-    };
-  }
-
-  return {
-    expired: false,
-    parts: [
-      { unit: "minutes", value: minutes },
-      { unit: "seconds", value: seconds },
-    ],
-  };
 };
 
 const normalize = (s?: string) =>


### PR DESCRIPTION
## Summary
- extract reusable countdown helpers into a shared time utility
- display the previous variant price and real-time sale countdown on product cards
- extend Arabic and Hebrew strings to surface the new sale countdown messaging

## Testing
- npm run lint *(fails: repository contains numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f784d8ae788330ba1902b942833fd2