### PR TITLE
Send SMS confirmation after creating orders

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,11 +2,10 @@
 const express = require("express");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
-const axios = require("axios");
-const qs = require("querystring");
 const crypto = require("crypto");
 const User = require("../models/User");
 const { getJwtSecret } = require("../utils/config");
+const { sendSMSHTD, normalizePhone } = require("../utils/sms");
 
 const router = express.Router();
 
@@ -23,164 +22,16 @@ const RESET_PASSWORD_MAX_ATTEMPTS =
 const RESET_PASSWORD_THROTTLE_MESSAGE =
   "تجاوزت الحد المسموح لمحاولات التحقق. اطلب رمزًا جديدًا.";
 
-/* =========================
-   ضبط بيئة/إعدادات
-========================= */
 const JWT_SECRET = getJwtSecret();
-
-/** قاعدة HTD (تستطيع تغييرها) */
-const HTD_BASE =
-  process.env.SMS_HTD_BASE || process.env.SMS_BASE || "http://sms.htd.ps/API";
-
-/** نمط الـ API: classic | simple | auto (افتراضي) */
-const HTD_API_STYLE = String(
-  process.env.SMS_HTD_API_STYLE || "auto"
-).toLowerCase();
-
-/** دعم أسماء متعددة لمتغيرات البيئة */
-const SMS_USERNAME = process.env.SMS_USERNAME || process.env.SMS_USER || ""; // مستخدم للنمط الكلاسيكي إن وُجد
-
-const SMS_PASSWORD =
-  process.env.SMS_PASSWORD ||
-  process.env.SMS_PASS ||
-  process.env.SMS_HTD_PASSWORD ||
-  process.env.SMS_HTD_PASS ||
-  ""; // قد لا يلزم
-
-/** اسم المُرسل: يدعم SMS_SENDER أو SMS_HTD_SENDER */
-const SMS_SENDER =
-  process.env.SMS_SENDER || process.env.SMS_HTD_SENDER || "SENDER";
-
-/** معرّف HTD للنمط البسيط (id) */
-const SMS_HTD_ID = process.env.SMS_HTD_ID || process.env.SMS_ID || "";
-
-/** مفاتيح تحكّم بالإرسال */
-const SEND_SMS_ENABLED =
-  String(process.env.SEND_SMS_ENABLED || "false").toLowerCase() === "true";
-const DEV_ECHO_OTP =
-  String(process.env.DEV_ECHO_OTP || "true").toLowerCase() === "true";
-
-/** تنسيق الرقم الافتراضي
- *  - لو النمط simple: نفضّل INT (97059xxxxxxx)
- *  - غير ذلك: نستخدم ما في البيئة أو E164 افتراضيًا
- */
-const DEFAULT_RECIPIENT_FORMAT =
-  HTD_API_STYLE === "simple"
-    ? "INT"
-    : (process.env.SMS_RECIPIENT_FORMAT || "E164").toUpperCase();
 
 /* =========================
    أدوات مساعدة
 ========================= */
-function normalizePhone(phone) {
-  if (!phone) return null;
-  let p = String(phone).trim().replace(/\s+/g, "");
-  p = p.replace(/[^\d+]/g, "");
-  if (!p.startsWith("+")) p = p.replace(/^0+/, "");
-  if (!p.startsWith("+")) p = "+970" + p;
-  return p;
-}
-
 function normalizeEmail(email) {
   if (!email) return null;
   const e = String(email).trim().toLowerCase();
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)) return null;
   return e;
-}
-
-function formatForProvider(e164Phone, preferFormat = DEFAULT_RECIPIENT_FORMAT) {
-  if (!e164Phone) return null;
-  const digits = e164Phone.replace(/^\+/, ""); // 97059xxxxxxx
-  if (preferFormat === "E164") return e164Phone; // +97059xxxxxxx
-  if (preferFormat === "INT") return digits; // 97059xxxxxxx
-  if (preferFormat === "LOCAL") {
-    // 059xxxxxxx
-    if (digits.startsWith("970")) {
-      const rest = digits.slice(3);
-      return "0" + rest;
-    }
-    return "0" + digits;
-  }
-  return digits; // افتراضي INT
-}
-
-/** يحدّد نمط الـ API المستخدم فعليًا */
-function resolveApiStyle() {
-  if (HTD_API_STYLE === "simple" || HTD_API_STYLE === "classic")
-    return HTD_API_STYLE;
-  // auto:
-  // إن وُجد id (SMS_HTD_ID) ولا يوجد UserName صريح، نستخدم simple
-  if (SMS_HTD_ID && !SMS_USERNAME) return "simple";
-  // إن وُجد UserName (أو Password)، نستخدم classic
-  if (SMS_USERNAME || SMS_PASSWORD) return "classic";
-  // fallback: simple
-  return "simple";
-}
-
-async function sendSMSHTD(toE164, text) {
-  if (!toE164 || !text) return { ok: false, reason: "missing_to_or_text" };
-
-  const style = resolveApiStyle();
-  const to = formatForProvider(
-    toE164,
-    style === "simple" ? "INT" : DEFAULT_RECIPIENT_FORMAT
-  );
-
-  // وضع التطوير: اطبع بدل الإرسال
-  if (!SEND_SMS_ENABLED) {
-    if (DEV_ECHO_OTP) {
-      console.log(
-        `[DEV SMS] To: ${toE164} (provider:${to}) | Message: ${text}`
-      );
-    }
-    return { ok: true, dev: true, style };
-  }
-
-  try {
-    const base = HTD_BASE.replace(/\/+$/, "");
-    const url = `${base}/SendSMS.aspx`;
-
-    let payload;
-    if (style === "simple") {
-      // ✅ النمط الذي أرسلته:
-      // SendSMS.aspx?id=...&sender=...&to=970xxxxxxx&msg=MessageHere
-      payload = {
-        id: SMS_HTD_ID, // لازم توفّره في .env
-        sender: SMS_SENDER,
-        to: to, // 97059xxxxxxx
-        msg: text,
-      };
-      if (!payload.id) {
-        return { ok: false, reason: "missing_SMS_HTD_ID_for_simple_mode" };
-      }
-    } else {
-      // 🧩 النمط الكلاسيكي:
-      // SendSMS.aspx?UserName=...&Password=...&SenderName=...&Recipients=...&Message=...
-      payload = {
-        SenderName: SMS_SENDER,
-        Recipients: to,
-        Message: text,
-      };
-      if (SMS_USERNAME) payload.UserName = SMS_USERNAME;
-      if (SMS_PASSWORD) payload.Password = SMS_PASSWORD;
-    }
-
-    const full = url + "?" + qs.stringify(payload);
-    const res = await axios.get(full, { timeout: 15000 });
-
-    console.log(
-      `[HTD SMS] style=${style} status=${res.status} data=`,
-      res.data
-    );
-    return { ok: true, style, status: res.status, data: res.data };
-  } catch (e) {
-    console.error(
-      "[HTD SMS] Error:",
-      e?.response?.status,
-      e?.response?.data || e?.message
-    );
-    return { ok: false, reason: e?.message || "send_failed" };
-  }
 }
 
 /* =========================

--- a/server/utils/sms.js
+++ b/server/utils/sms.js
@@ -2,44 +2,155 @@
 const axios = require("axios");
 const qs = require("querystring");
 
-const HTD_BASE = "http://sms.htd.ps/API";
-const HTD_ID = process.env.SMS_HTD_ID;
-const HTD_SENDER = process.env.SMS_HTD_SENDER || "Dikori"; // عدّل اسم المرسل
+const HTD_BASE =
+  process.env.SMS_HTD_BASE || process.env.SMS_BASE || "http://sms.htd.ps/API";
+const HTD_API_STYLE = String(
+  process.env.SMS_HTD_API_STYLE || "auto"
+).toLowerCase();
 
-function buildTo(msisdn) {
-  // تأكد من أن الرقم بصيغة 970XXXXXXXXX بدون +
-  let to = String(msisdn || "").replace(/[^\d]/g, "");
-  if (to.startsWith("0")) to = "970" + to.slice(1);
-  if (!to.startsWith("970")) to = "970" + to;
-  return to;
+const SMS_USERNAME = process.env.SMS_USERNAME || process.env.SMS_USER || "";
+const SMS_PASSWORD =
+  process.env.SMS_PASSWORD ||
+  process.env.SMS_PASS ||
+  process.env.SMS_HTD_PASSWORD ||
+  process.env.SMS_HTD_PASS ||
+  "";
+
+const SMS_SENDER =
+  process.env.SMS_SENDER || process.env.SMS_HTD_SENDER || "SENDER";
+
+const SMS_HTD_ID = process.env.SMS_HTD_ID || process.env.SMS_ID || "";
+
+const SEND_SMS_ENABLED =
+  String(process.env.SEND_SMS_ENABLED || "false").toLowerCase() === "true";
+
+const DEV_ECHO_SMS =
+  String(
+    process.env.DEV_ECHO_SMS ||
+      process.env.DEV_ECHO_OTP ||
+      process.env.DEV_ECHO_SMS_MESSAGES ||
+      "true"
+  ).toLowerCase() === "true";
+
+const DEFAULT_RECIPIENT_FORMAT =
+  HTD_API_STYLE === "simple"
+    ? "INT"
+    : (process.env.SMS_RECIPIENT_FORMAT || "E164").toUpperCase();
+
+function normalizePhone(phone) {
+  if (!phone) return null;
+  let p = String(phone).trim().replace(/\s+/g, "");
+  p = p.replace(/[^\d+]/g, "");
+  if (!p) return null;
+  if (!p.startsWith("+")) p = p.replace(/^0+/, "");
+  if (!p) return null;
+  if (!p.startsWith("+")) p = "+970" + p;
+  if (!p.startsWith("+")) p = "+" + p;
+  return p;
 }
 
-async function sendSMS({ to, msg }) {
-  if (!HTD_ID) throw new Error("Missing SMS_HTD_ID env");
-  const safeTo = buildTo(to);
-  const url = `${HTD_BASE}/SendSMS.aspx`;
-  // واجهة HTD تستخدم GET مع باراميتر id/sender/to/msg
-  const query = {
-    id: HTD_ID,
-    sender: HTD_SENDER,
-    to: safeTo,
-    msg, // HTD يقوم بترميزها داخلياً عادة؛ نتركها كـ raw
-  };
-  const full = `${url}?${qs.stringify(query)}`;
-  const { data, status } = await axios.get(full, { timeout: 15000 });
-  // رجّع الرد كما هو؛ تقدر تخصّص فحص النجاح حسب تنسيق HTD
-  return { ok: status === 200, raw: data };
+function formatForProvider(e164Phone, preferFormat = DEFAULT_RECIPIENT_FORMAT) {
+  if (!e164Phone) return null;
+  const digits = e164Phone.replace(/^\+/, "");
+  if (!digits) return null;
+  if (preferFormat === "E164") return e164Phone;
+  if (preferFormat === "INT") return digits;
+  if (preferFormat === "LOCAL") {
+    if (digits.startsWith("970")) {
+      const rest = digits.slice(3);
+      return rest ? `0${rest}` : null;
+    }
+    return `0${digits}`;
+  }
+  return digits;
+}
+
+function resolveApiStyle() {
+  if (HTD_API_STYLE === "simple" || HTD_API_STYLE === "classic") {
+    return HTD_API_STYLE;
+  }
+  if (SMS_HTD_ID && !SMS_USERNAME) return "simple";
+  if (SMS_USERNAME || SMS_PASSWORD) return "classic";
+  return "simple";
+}
+
+async function sendSMSHTD(to, text, options = {}) {
+  if (!to || !text) return { ok: false, reason: "missing_to_or_text" };
+
+  const normalized = normalizePhone(to);
+  if (!normalized) return { ok: false, reason: "invalid_phone" };
+
+  const style = resolveApiStyle();
+  const preferFormat =
+    options.preferFormat || (style === "simple" ? "INT" : DEFAULT_RECIPIENT_FORMAT);
+  const providerRecipient = formatForProvider(normalized, preferFormat);
+  if (!providerRecipient) return { ok: false, reason: "invalid_recipient" };
+
+  if (!SEND_SMS_ENABLED) {
+    if (DEV_ECHO_SMS) {
+      const label = options.label ? `[${options.label}] ` : "";
+      console.log(
+        `[DEV SMS] ${label}To: ${normalized} (provider:${providerRecipient}) | Message: ${text}`
+      );
+    }
+    return { ok: true, dev: true, style };
+  }
+
+  try {
+    const base = HTD_BASE.replace(/\/+$/, "");
+    const url = `${base}/SendSMS.aspx`;
+
+    let payload;
+    if (style === "simple") {
+      payload = {
+        id: SMS_HTD_ID,
+        sender: SMS_SENDER,
+        to: providerRecipient,
+        msg: text,
+      };
+      if (!payload.id) {
+        return { ok: false, reason: "missing_SMS_HTD_ID_for_simple_mode" };
+      }
+    } else {
+      payload = {
+        SenderName: SMS_SENDER,
+        Recipients: providerRecipient,
+        Message: text,
+      };
+      if (SMS_USERNAME) payload.UserName = SMS_USERNAME;
+      if (SMS_PASSWORD) payload.Password = SMS_PASSWORD;
+    }
+
+    const full = `${url}?${qs.stringify(payload)}`;
+    const res = await axios.get(full, { timeout: options.timeoutMs || 15000 });
+
+    console.log(
+      `[HTD SMS] style=${style} status=${res.status} data=`,
+      res.data
+    );
+
+    return { ok: true, style, status: res.status, data: res.data };
+  } catch (err) {
+    console.error(
+      "[HTD SMS] Error:",
+      err?.response?.status,
+      err?.response?.data || err?.message
+    );
+    return { ok: false, reason: err?.message || "send_failed", error: err };
+  }
 }
 
 async function getCredit() {
-  if (!HTD_ID) throw new Error("Missing SMS_HTD_ID env");
-  const url = `${HTD_BASE}/GetCredit.aspx?id=${encodeURIComponent(HTD_ID)}`;
+  if (!SMS_HTD_ID) throw new Error("Missing SMS_HTD_ID env");
+  const base = HTD_BASE.replace(/\/+$/, "");
+  const url = `${base}/GetCredit.aspx?id=${encodeURIComponent(SMS_HTD_ID)}`;
   const { data, status } = await axios.get(url, { timeout: 10000 });
   return { ok: status === 200, raw: data };
 }
 
 module.exports = {
-  sendSMS,
+  sendSMSHTD,
   getCredit,
-  buildTo,
+  normalizePhone,
+  formatForProvider,
 };


### PR DESCRIPTION
## Summary
- consolidate the HTD SMS client so it can be reused outside of the auth routes
- trigger SMS confirmations after COD and card order creation with formatted order summaries
- add helpers to format order details and validate phone numbers before sending

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f8aab6d4888330a80a36cb5edaa268