### PR TITLE
Add payment card metadata to order notifications

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -112,6 +112,8 @@ const OrderSchema = new mongoose.Schema(
     paymentVerifiedAmount: { type: Number, min: 0, default: null },
     paymentVerifiedCurrency: { type: String, default: "" },
     paymentTransactionId: { type: String, default: "" },
+    paymentCardType: { type: String, default: "" },
+    paymentCardLast4: { type: String, default: "" },
     notes: { type: String, default: "" },
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- capture card type and last four digits from Lahza verification responses and persist them on orders
- extend the order confirmation SMS to mention payment method, card details, and the order timestamp
- ensure admin payment confirmation also stores the extracted card metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f9cd168f488330a7fc70f149754320