### PR TITLE
Send SMS order summaries after checkout

### DIFF
--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -112,6 +112,8 @@ const OrderSchema = new mongoose.Schema(
     paymentVerifiedAmount: { type: Number, min: 0, default: null },
     paymentVerifiedCurrency: { type: String, default: "" },
     paymentTransactionId: { type: String, default: "" },
+    paymentCardType: { type: String, default: "" },
+    paymentCardLast4: { type: String, default: "" },
     notes: { type: String, default: "" },
   },
   { timestamps: true }

--- a/server/test/order-sms.test.js
+++ b/server/test/order-sms.test.js
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildOrderSummaryMessage } = require("../utils/orderSms");
+
+test("buildOrderSummaryMessage includes key order details", () => {
+  const createdAt = new Date("2024-03-12T09:15:00Z");
+  const order = {
+    user: { name: "أحمد", phone: "0590000000" },
+    guestInfo: { name: "", phone: "" },
+    items: [
+      {
+        name: { ar: "منتج رائع", he: "" },
+        quantity: 2,
+        price: 49.5,
+      },
+      {
+        name: { ar: "منتج إضافي", he: "" },
+        quantity: 1,
+        price: 20,
+      },
+    ],
+    subtotal: 119,
+    discount: { amount: 9 },
+    total: 110,
+    paymentCurrency: "ILS",
+    paymentMethod: "card",
+    createdAt,
+    reference: "REF-12345",
+  };
+
+  const message = buildOrderSummaryMessage({
+    order,
+    cardTypeOverride: "Visa",
+    cardLast4Override: "0444",
+  });
+
+  assert.match(message, /أحمد/);
+  assert.match(message, /0590000000/);
+  assert.match(message, /2024-03-12/);
+  assert.match(message, /منتج رائع x2/);
+  assert.match(message, /49\.50 ILS/);
+  assert.match(message, /الإجمالي المطلوب: 110\.00 ILS/);
+  assert.match(message, /الخصم: 9\.00 ILS/);
+  assert.match(message, /طريقة الدفع: Visa \*\*\*\*0444/);
+  assert.match(message, /مرجع الدفع: REF-12345/);
+});
+
+test("buildOrderSummaryMessage falls back to COD label", () => {
+  const order = {
+    guestInfo: { name: "ضيف", phone: "0591111111" },
+    items: [
+      { name: { ar: "منتج" }, quantity: 1, price: 15 },
+    ],
+    subtotal: 15,
+    discount: { amount: 0 },
+    total: 15,
+    paymentCurrency: "ILS",
+    paymentMethod: "cod",
+    createdAt: new Date("2024-01-01T10:00:00Z"),
+  };
+
+  const message = buildOrderSummaryMessage({ order });
+
+  assert.match(message, /ضيف/);
+  assert.match(message, /طريقة الدفع: الدفع عند الاستلام/);
+});

--- a/server/utils/orderSms.js
+++ b/server/utils/orderSms.js
@@ -1,0 +1,217 @@
+// server/utils/orderSms.js
+const { sendSMSHTD, normalizePhone } = require("./smsHtd");
+
+function toPlainObject(order) {
+  if (!order) return null;
+  if (typeof order.toObject === "function") {
+    try {
+      return order.toObject({ depopulate: true, virtuals: false });
+    } catch {
+      return order.toObject();
+    }
+  }
+  return order;
+}
+
+function resolveCustomerName(order) {
+  const userName = order?.user?.name;
+  const guestName = order?.guestInfo?.name;
+  const name = (userName || guestName || "").toString().trim();
+  return name || "عميلنا العزيز";
+}
+
+function resolveCustomerPhone(order) {
+  const phone = order?.user?.phone || order?.guestInfo?.phone || "";
+  const trimmed = phone ? String(phone).trim() : "";
+  return trimmed || null;
+}
+
+function normalizeCurrency(currency) {
+  return currency ? String(currency).trim().toUpperCase() : "";
+}
+
+function formatCurrency(amount, currency) {
+  const num = Number(amount);
+  const safe = Number.isFinite(num) ? num : 0;
+  const formatted = safe.toFixed(2);
+  const code = normalizeCurrency(currency);
+  return code ? `${formatted} ${code}` : formatted;
+}
+
+function getItemName(item = {}) {
+  if (!item) return "منتج";
+  if (typeof item.name === "string" && item.name.trim()) {
+    return item.name.trim();
+  }
+  if (item.name && typeof item.name === "object") {
+    const ar = item.name.ar && String(item.name.ar).trim();
+    const he = item.name.he && String(item.name.he).trim();
+    if (ar) return ar;
+    if (he) return he;
+  }
+  return "منتج";
+}
+
+function formatOrderDate(value) {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function cleanCardType(raw) {
+  if (!raw) return "";
+  const text = String(raw).trim();
+  if (!text) return "";
+  const lower = text.toLowerCase();
+  if (lower === "cod" || lower === "cash" || lower === "cash_on_delivery") {
+    return "";
+  }
+  if (lower === "card") {
+    return "بطاقة";
+  }
+  return text
+    .split(/\s+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function cleanLast4(raw) {
+  if (!raw && raw !== 0) return "";
+  const text = String(raw).replace(/\D+/g, "");
+  if (!text) return "";
+  return text.slice(-4).padStart(4, "0");
+}
+
+function buildOrderSummaryMessage({
+  order,
+  cardTypeOverride = "",
+  cardLast4Override = "",
+} = {}) {
+  const safeOrder = toPlainObject(order) || {};
+  const name = resolveCustomerName(safeOrder);
+  const phone = resolveCustomerPhone(safeOrder) || "";
+  const currency = safeOrder.paymentCurrency || safeOrder.currency;
+  const createdAt = formatOrderDate(safeOrder.createdAt || safeOrder.updatedAt);
+  const cardType =
+    cleanCardType(
+      cardTypeOverride || safeOrder.paymentCardType || safeOrder.paymentMethod
+    ) || (safeOrder.paymentMethod === "cod" ? "الدفع عند الاستلام" : "");
+  const cardLast4 =
+    cleanLast4(cardLast4Override || safeOrder.paymentCardLast4) || "";
+
+  const lines = [];
+  lines.push(`مرحبا ${name}`);
+  if (phone) {
+    lines.push(`هاتف: ${phone}`);
+  }
+  if (createdAt) {
+    lines.push(`تاريخ الطلب: ${createdAt}`);
+  }
+
+  lines.push("تفاصيل الطلب:");
+  const items = Array.isArray(safeOrder.items) ? safeOrder.items : [];
+  const currencyLabel = normalizeCurrency(currency);
+  for (const item of items) {
+    const itemName = getItemName(item);
+    const qty = Math.max(1, Number.parseInt(item?.quantity, 10) || 1);
+    const unitPrice = Number.isFinite(Number(item?.price))
+      ? Number(item.price)
+      : 0;
+    const lineTotal = unitPrice * qty;
+    const priceText = formatCurrency(unitPrice, currencyLabel || safeOrder.paymentCurrency);
+    const totalText = formatCurrency(lineTotal, currencyLabel || safeOrder.paymentCurrency);
+    lines.push(`- ${itemName} x${qty}: ${priceText} للوحدة / ${totalText} الإجمالي`);
+  }
+
+  const subtotal = formatCurrency(safeOrder.subtotal, currencyLabel || safeOrder.paymentCurrency);
+  const discountValue = Number(safeOrder?.discount?.amount || 0);
+  const total = formatCurrency(safeOrder.total, currencyLabel || safeOrder.paymentCurrency);
+
+  lines.push(`المجموع قبل الخصم: ${subtotal}`);
+  if (discountValue > 0) {
+    lines.push(`الخصم: ${formatCurrency(discountValue, currencyLabel || safeOrder.paymentCurrency)}`);
+  }
+  lines.push(`الإجمالي المطلوب: ${total}`);
+
+  if (cardType) {
+    const parts = [cardType];
+    if (cardLast4) {
+      parts.push(`****${cardLast4}`);
+    }
+    lines.push(`طريقة الدفع: ${parts.join(" ")}`);
+  }
+
+  if (safeOrder.reference) {
+    lines.push(`مرجع الدفع: ${safeOrder.reference}`);
+  }
+
+  lines.push("شكرا لتسوقك من ديكوري!");
+
+  return lines.join("\n");
+}
+
+async function sendOrderSummarySMS({
+  order,
+  cardType,
+  cardLast4,
+} = {}) {
+  const safeOrder = toPlainObject(order);
+  if (!safeOrder) {
+    return { ok: false, reason: "missing_order" };
+  }
+
+  const phone = resolveCustomerPhone(safeOrder);
+  if (!phone) {
+    return { ok: false, reason: "missing_phone" };
+  }
+
+  const normalizedPhone = normalizePhone(phone);
+  if (!normalizedPhone) {
+    return { ok: false, reason: "invalid_phone" };
+  }
+
+  const message = buildOrderSummaryMessage({
+    order: safeOrder,
+    cardTypeOverride: cardType,
+    cardLast4Override: cardLast4,
+  });
+
+  try {
+    const result = await sendSMSHTD(normalizedPhone, message);
+    if (!result?.ok) {
+      return { ok: false, reason: result?.reason || "send_failed" };
+    }
+    return { ok: true, result };
+  } catch (err) {
+    console.error("Failed to send order summary SMS:", err?.message || err);
+    return { ok: false, reason: err?.message || "send_failed" };
+  }
+}
+
+function queueOrderSummarySMS(options) {
+  if (!options || !options.order) return;
+  Promise.resolve()
+    .then(() => sendOrderSummarySMS(options))
+    .then((result) => {
+      if (!result?.ok) {
+        const reason = result?.reason || "unknown_reason";
+        if (reason === "missing_phone" || reason === "invalid_phone") {
+          return;
+        }
+        console.warn("Order summary SMS was not sent:", reason);
+      }
+    })
+    .catch((err) => {
+      console.error("Order summary SMS error:", err?.message || err);
+    });
+}
+
+module.exports = {
+  sendOrderSummarySMS,
+  queueOrderSummarySMS,
+  buildOrderSummaryMessage,
+};

--- a/server/utils/smsHtd.js
+++ b/server/utils/smsHtd.js
@@ -1,0 +1,137 @@
+// server/utils/smsHtd.js
+const axios = require("axios");
+const qs = require("querystring");
+
+/**
+ * إعدادات وبيئة مزود HTD للرسائل القصيرة.
+ * تمت مشاركتها بين مسارات مختلفة لضمان سلوك موحد عند إرسال الرسائل.
+ */
+const HTD_BASE =
+  process.env.SMS_HTD_BASE || process.env.SMS_BASE || "http://sms.htd.ps/API";
+
+const HTD_API_STYLE = String(
+  process.env.SMS_HTD_API_STYLE || "auto"
+).toLowerCase();
+
+const SMS_USERNAME = process.env.SMS_USERNAME || process.env.SMS_USER || "";
+const SMS_PASSWORD =
+  process.env.SMS_PASSWORD ||
+  process.env.SMS_PASS ||
+  process.env.SMS_HTD_PASSWORD ||
+  process.env.SMS_HTD_PASS ||
+  "";
+const SMS_SENDER =
+  process.env.SMS_SENDER || process.env.SMS_HTD_SENDER || "SENDER";
+const SMS_HTD_ID = process.env.SMS_HTD_ID || process.env.SMS_ID || "";
+
+const SEND_SMS_ENABLED =
+  String(process.env.SEND_SMS_ENABLED || "false").toLowerCase() === "true";
+const DEV_ECHO_SMS = String(
+  process.env.DEV_ECHO_SMS ?? process.env.DEV_ECHO_OTP ?? "true"
+).toLowerCase() === "true";
+
+const DEFAULT_RECIPIENT_FORMAT =
+  HTD_API_STYLE === "simple"
+    ? "INT"
+    : (process.env.SMS_RECIPIENT_FORMAT || "E164").toUpperCase();
+
+function normalizePhone(phone) {
+  if (!phone) return null;
+  let p = String(phone).trim().replace(/\s+/g, "");
+  p = p.replace(/[^\d+]/g, "");
+  if (!p.startsWith("+")) p = p.replace(/^0+/, "");
+  if (!p.startsWith("+")) p = "+970" + p;
+  return p;
+}
+
+function formatForProvider(e164Phone, preferFormat = DEFAULT_RECIPIENT_FORMAT) {
+  if (!e164Phone) return null;
+  const digits = e164Phone.replace(/^\+/, "");
+  if (preferFormat === "E164") return e164Phone;
+  if (preferFormat === "INT") return digits;
+  if (preferFormat === "LOCAL") {
+    if (digits.startsWith("970")) {
+      const rest = digits.slice(3);
+      return "0" + rest;
+    }
+    return "0" + digits;
+  }
+  return digits;
+}
+
+function resolveApiStyle() {
+  if (HTD_API_STYLE === "simple" || HTD_API_STYLE === "classic") {
+    return HTD_API_STYLE;
+  }
+  if (SMS_HTD_ID && !SMS_USERNAME) return "simple";
+  if (SMS_USERNAME || SMS_PASSWORD) return "classic";
+  return "simple";
+}
+
+async function sendSMSHTD(toE164, text) {
+  if (!toE164 || !text) return { ok: false, reason: "missing_to_or_text" };
+
+  const style = resolveApiStyle();
+  const to = formatForProvider(
+    toE164,
+    style === "simple" ? "INT" : DEFAULT_RECIPIENT_FORMAT
+  );
+
+  if (!SEND_SMS_ENABLED) {
+    if (DEV_ECHO_SMS) {
+      console.log(
+        `[DEV SMS] To: ${toE164} (provider:${to}) | Message: ${text}`
+      );
+    }
+    return { ok: true, dev: true, style };
+  }
+
+  try {
+    const base = HTD_BASE.replace(/\/+$/, "");
+    const url = `${base}/SendSMS.aspx`;
+
+    let payload;
+    if (style === "simple") {
+      payload = {
+        id: SMS_HTD_ID,
+        sender: SMS_SENDER,
+        to,
+        msg: text,
+      };
+      if (!payload.id) {
+        return { ok: false, reason: "missing_SMS_HTD_ID_for_simple_mode" };
+      }
+    } else {
+      payload = {
+        SenderName: SMS_SENDER,
+        Recipients: to,
+        Message: text,
+      };
+      if (SMS_USERNAME) payload.UserName = SMS_USERNAME;
+      if (SMS_PASSWORD) payload.Password = SMS_PASSWORD;
+      if (!payload.UserName || !payload.Password) {
+        return { ok: false, reason: "missing_credentials_for_classic_mode" };
+      }
+    }
+
+    const full = url + "?" + qs.stringify(payload);
+    const res = await axios.get(full, { timeout: 15000 });
+
+    console.log(`[HTD SMS] style=${style} status=${res.status} data=`, res.data);
+    return { ok: true, style, status: res.status, data: res.data };
+  } catch (e) {
+    console.error(
+      "[HTD SMS] Error:",
+      e?.response?.status,
+      e?.response?.data || e?.message
+    );
+    return { ok: false, reason: e?.message || "send_failed" };
+  }
+}
+
+module.exports = {
+  sendSMSHTD,
+  normalizePhone,
+  formatForProvider,
+  resolveApiStyle,
+};


### PR DESCRIPTION
## Summary
- centralize HTD SMS client logic and reuse it for authentication and order notifications
- queue detailed order summary SMS messages after COD creation and successful card payments, including card brand and last four digits
- extract card metadata from Lahza responses, persist it on orders, and add unit coverage for the SMS formatter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa0637336c83308599e885616a4ee0